### PR TITLE
spec: add tests around rescue handler invocation context

### DIFF
--- a/spec/support/shared_context/shared_context_for_rescue.rb
+++ b/spec/support/shared_context/shared_context_for_rescue.rb
@@ -32,8 +32,12 @@ RSpec.shared_context "with rescuable actor handler" do
   let(:error_instance) { error_class.new "my error" }
   let(:action_filter) { nil }
   let(:format_filter) { nil }
+  let(:rescue_context) { self }
   let(:visited_errors) { [] }
   let(:rescuable) do
-    klazz.rescue_actor(error_instance, action: action_filter, format: format_filter, visited: visited_errors)
+    klazz.rescue_actor(
+      error_instance,
+      action: action_filter, format: format_filter, context: rescue_context, visited: visited_errors
+    )
   end
 end


### PR DESCRIPTION
add tests around rescue handler context
- ensure proc/block is being executed at context level
- handlers are processed according to the declaring order in reverse
- handler only receive the error when its action/format filter matched
