### PR TITLE
fix: alias compose_scene to act_on_format

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -27,7 +27,7 @@ class EventsController < ActionController::Base
     before_action only: :index { @events = Event.all }
 
     # dynamically defines the action method according to on: argument
-    compose_scene :html, :json, on: :index 
+    act_on_format :html, :json, on: :index 
 
     def index_html
         @event_categories = EventCategory.all
@@ -92,7 +92,7 @@ class EventsController < ActionController::Base
     # AbstractController::Callbacks here to load model with params
     before_action only: [:show, :update] { @event = Event.find(params.require(:event_id)) }
 
-    compose_scene :html, :json, on: [:show, :update]
+    act_on_format :html, :json, on: [:show, :update]
 
     rescue_actor_from ActiveRecord::RecordNotFound, format: :json do |ex|
         render status: :bad_request, json: { error: ex.message }

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ class EventsController < ActionController::Base
     before_action only: :index { @events = Event.all }
     before_action only: [:show, :update] { @event = Event.find(params.require(:event_id)) }
 
-    compose_scene :html, :json, on: :index
-    compose_scene :html, :json, on: [:show, :update]
+    act_on_format :html, :json, on: :index
+    act_on_format :html, :json, on: [:show, :update]
 
     rescue_actor_from ActiveRecord::RecordNotFound, format: :json do |ex|
         render status: :bad_request, json: { error: "Resouce not found" }

--- a/lib/mime_actor/logging.rb
+++ b/lib/mime_actor/logging.rb
@@ -10,7 +10,7 @@ require "active_support/tagged_logging"
 
 module MimeActor
   # # MimeActor Logging
-  # 
+  #
   # Provides a configurable logger.
   module Logging
     extend ActiveSupport::Concern

--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -39,7 +39,7 @@ module MimeActor
       #
       # @example Rescue StandardError when raised for any action with `html` format
       #   rescue_actor_from StandardError, format: :html, with: :handle_html_error
-      #     
+      #
       # @example Rescue StandardError when raised for `show` action with `json` format
       #   rescue_actor_from StandardError, format: :json, action: :show do |ex|
       #     render status: :bad_request, json: { error: ex.message }

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -80,6 +80,8 @@ module MimeActor
           end
         end
       end
+
+      alias act_on_format compose_scene
     end
   end
 end

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -16,9 +16,9 @@ module MimeActor
   # Scene provides configuration for `action` + `format` definitions
   #
   # @example register a `html` format on action `index`
-  #     compose_scene :html, on: :index
+  #     act_on_format :html, on: :index
   # @example register `html`, `json` formats on actions `index`, `show`
-  #     compose_scene :html, :json , on: [:index, :show]
+  #     act_on_format :html, :json , on: [:index, :show]
   #
   # NOTE: Calling the same `action`/`format` multiple times will overwrite previous `action` + `format` definitions.
   #

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -48,7 +48,7 @@ module MimeActor
       #   dispatch = self.class.dispatch_cue(action: :create, format: :json, context: self) do
       #       puts "completed the dispatch"
       #   end
-      #   
+      #
       #   dispatch.call == "completed the dispatch" # true
       #
       def dispatch_cue(action: nil, format: nil, context: self, &block)
@@ -63,7 +63,7 @@ module MimeActor
     end
 
     # Calls the `actor` method if defined, supports passing arguments to the `actor` method.
-    # 
+    #
     # If a block is given, the result from the `actor` method will be yieled to the block.
     #
     # @param actor_name

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -13,7 +13,7 @@ module MimeActor
   #
   # @example Raise error when rule is violated
   #   validate!(:action, action_param)
-  #     
+  #
   # @example Return the error when rule is violated
   #   ex = validate_action(action_param)
   #   raise ex if error

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -5,6 +5,14 @@ require "mime_actor/scene"
 RSpec.describe MimeActor::Scene do
   let(:klazz) { Class.new.include described_class }
 
+  describe "#act_on_format" do
+    it "alias #compose_scene" do
+      expect(klazz).not_to be_method_defined(:act_on_format)
+      expect(klazz.singleton_class).to be_method_defined(:act_on_format)
+      expect(klazz.method(:act_on_format)).to eq klazz.method(:compose_scene)
+    end
+  end
+
   describe "#compose_scene" do
     describe "#action" do
       it_behaves_like "composable scene action", "nil", acceptance: false do


### PR DESCRIPTION
alias `#compose_scene` to `#act_on_format` to better align with `#rescue_actor_from`