### PR TITLE
fix: promote `#act_on_format` to the public API

### DIFF
--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor method is defined" do
     before do
-      controller_class.compose_scene :json, on: :new
+      controller_class.act_on_format :json, on: :new
       controller_class.define_method(action_actor) { render plain: :ok }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor methods for some formats are undefined" do
     before do
-      controller_class.compose_scene :json, :html, on: :new
+      controller_class.act_on_format :json, :html, on: :new
       controller_class.define_method(:new_html) { render plain: :ok }
     end
 

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe MimeActor::Scene do
   let(:klazz) { Class.new.include described_class }
 
   describe "#act_on_format" do
-    it "alias #compose_scene" do
-      expect(klazz).not_to be_method_defined(:act_on_format)
-      expect(klazz.singleton_class).to be_method_defined(:act_on_format)
-      expect(klazz.method(:act_on_format)).to eq klazz.method(:compose_scene)
-    end
-  end
-
-  describe "#compose_scene" do
     describe "#action" do
       it_behaves_like "composable scene action", "nil", acceptance: false do
         let(:action_filter) { nil }
@@ -83,18 +75,18 @@ RSpec.describe MimeActor::Scene do
     describe "when is called multiple times" do
       it "merges the scenes" do
         expect(klazz.acting_scenes).to be_empty
-        klazz.compose_scene(:html, on: %i[index create])
+        klazz.act_on_format(:html, on: %i[index create])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html]
         )
-        klazz.compose_scene(:xml, on: %i[create update])
+        klazz.act_on_format(:xml, on: %i[create update])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html, :xml],
           update: Set[:xml]
         )
-        klazz.compose_scene(:json, :xml, on: %i[create show])
+        klazz.act_on_format(:json, :xml, on: %i[create show])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html, :xml, :json],

--- a/spec/support/shared_context/shared_context_for_scene.rb
+++ b/spec/support/shared_context/shared_context_for_scene.rb
@@ -8,5 +8,5 @@ RSpec.shared_context "with scene composition" do
   let(:action_params) { action_filters.size > 1 ? action_filters : action_filters.first }
   let(:format_filter) { :html }
   let(:format_filters) { Array.wrap(format_filter) }
-  let(:compose) { klazz.compose_scene(*format_filters, on: action_params) }
+  let(:compose) { klazz.act_on_format(*format_filters, on: action_params) }
 end


### PR DESCRIPTION
promote `#act_on_format` to the public API, `#compose_scene` remains a private method without args validations