### PR TITLE
refactor: act_on_format with respond_act_to

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -27,7 +27,7 @@ class EventsController < ActionController::Base
     before_action only: :index { @events = Event.all }
 
     # dynamically defines the action method according to on: argument
-    act_on_format :html, :json, on: :index 
+    respond_act_to :html, :json, on: :index 
 
     def index_html
         @event_categories = EventCategory.all
@@ -92,7 +92,7 @@ class EventsController < ActionController::Base
     # AbstractController::Callbacks here to load model with params
     before_action only: [:show, :update] { @event = Event.find(params.require(:event_id)) }
 
-    act_on_format :html, :json, on: [:show, :update]
+    respond_act_to :html, :json, on: [:show, :update]
 
     rescue_act_from ActiveRecord::RecordNotFound, format: :json do |ex|
         render status: :bad_request, json: { error: ex.message }

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ class EventsController < ActionController::Base
     before_action only: :index { @events = Event.all }
     before_action only: [:show, :update] { @event = Event.find(params.require(:event_id)) }
 
-    act_on_format :html, :json, on: :index
-    act_on_format :html, :json, on: [:show, :update]
+    respond_act_to :html, :json, on: :index
+    respond_act_to :html, :json, on: [:show, :update]
 
     rescue_act_from ActiveRecord::RecordNotFound, format: :json do |ex|
         render status: :bad_request, json: { error: "Resouce not found" }

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -34,9 +34,8 @@ module MimeActor
     class_methods do
       # Register `action` + `format` definitions.
       #
-      # @param options [Array]
-      # @option options [Array] klazzes the collection of `format`
-      # @option options [Hash] on the collection of `action`
+      # @param formats the collection of `format`
+      # @param on the collection of `action`
       #
       # @example register a `html` format on action `index`
       #   act_on_format :html, on: :index
@@ -44,11 +43,10 @@ module MimeActor
       #   act_on_format :html, :json , on: [:index, :show]
       #
       # For each unique `action` being registered, it will have a corresponding `action` method being defined.
-      def act_on_format(*options)
-        config = options.extract_options!
-        validate!(:formats, options)
+      def act_on_format(*formats, on: nil)
+        validate!(:formats, formats)
 
-        case actions = config[:on]
+        case actions = on
         when Enumerable
           validate!(:actions, actions)
         when Symbol, String
@@ -58,7 +56,7 @@ module MimeActor
         end
 
         Array.wrap(actions).each do |action|
-          options.each { |format| compose_scene(action, format) }
+          formats.each { |format| compose_scene(action, format) }
         end
       end
 

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -16,9 +16,9 @@ module MimeActor
   # Scene provides configuration for `action` + `format` definitions
   #
   # @example register a `html` format on action `index`
-  #     act_on_format :html, on: :index
+  #     respond_act_to :html, on: :index
   # @example register `html`, `json` formats on actions `index`, `show`
-  #     act_on_format :html, :json , on: [:index, :show]
+  #     respond_act_to :html, :json , on: [:index, :show]
   #
   # NOTE: Calling the same `action`/`format` multiple times will overwrite previous `action` + `format` definitions.
   #
@@ -38,12 +38,12 @@ module MimeActor
       # @param on the collection of `action`
       #
       # @example register a `html` format on action `index`
-      #   act_on_format :html, on: :index
+      #   respond_act_to :html, on: :index
       # @example register `html`, `json` formats on actions `index`, `show`
-      #   act_on_format :html, :json , on: [:index, :show]
+      #   respond_act_to :html, :json , on: [:index, :show]
       #
       # For each unique `action` being registered, it will have a corresponding `action` method being defined.
-      def act_on_format(*formats, on: nil)
+      def respond_act_to(*formats, on: nil)
         validate!(:formats, formats)
 
         case actions = on

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -60,6 +60,8 @@ module MimeActor
         end
       end
 
+      alias_method :act_on_format, :respond_act_to
+
       private
 
       def compose_scene(action, format)

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor method is defined" do
     before do
-      controller_class.act_on_format :json, on: :new
+      controller_class.respond_act_to :json, on: :new
       controller_class.define_method(action_actor) { render plain: :ok }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor methods for some formats are undefined" do
     before do
-      controller_class.act_on_format :json, :html, on: :new
+      controller_class.respond_act_to :json, :html, on: :new
       controller_class.define_method(:new_html) { render plain: :ok }
     end
 

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MimeActor::Action do
     let(:stub_logger) { instance_double(ActiveSupport::Logger) }
 
     before do
-      klazz.act_on_format :html, on: :create
+      klazz.respond_act_to :html, on: :create
       klazz.config.logger = stub_logger
     end
 

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -5,7 +5,7 @@ require "mime_actor/scene"
 RSpec.describe MimeActor::Scene do
   let(:klazz) { Class.new.include described_class }
 
-  describe "#act_on_format" do
+  describe "#respond_act_to" do
     describe "#action" do
       it_behaves_like "composable scene action", "nil", acceptance: false do
         let(:action_filter) { nil }
@@ -75,18 +75,18 @@ RSpec.describe MimeActor::Scene do
     describe "when is called multiple times" do
       it "merges the scenes" do
         expect(klazz.acting_scenes).to be_empty
-        klazz.act_on_format(:html, on: %i[index create])
+        klazz.respond_act_to(:html, on: %i[index create])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html]
         )
-        klazz.act_on_format(:xml, on: %i[create update])
+        klazz.respond_act_to(:xml, on: %i[create update])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html, :xml],
           update: Set[:xml]
         )
-        klazz.act_on_format(:json, :xml, on: %i[create show])
+        klazz.respond_act_to(:json, :xml, on: %i[create show])
         expect(klazz.acting_scenes).to include(
           index:  Set[:html],
           create: Set[:html, :xml, :json],

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -5,6 +5,14 @@ require "mime_actor/scene"
 RSpec.describe MimeActor::Scene do
   let(:klazz) { Class.new.include described_class }
 
+  describe "#act_on_format" do
+    it "alias #respond_act_to" do
+      expect(klazz).not_to be_method_defined(:act_on_format)
+      expect(klazz.singleton_class).to be_method_defined(:act_on_format)
+      expect(klazz.method(:act_on_format)).to eq klazz.method(:respond_act_to)
+    end
+  end
+
   describe "#respond_act_to" do
     describe "#action" do
       it_behaves_like "composable scene action", "nil", acceptance: false do

--- a/spec/support/shared_context/shared_context_for_scene.rb
+++ b/spec/support/shared_context/shared_context_for_scene.rb
@@ -8,5 +8,5 @@ RSpec.shared_context "with scene composition" do
   let(:action_params) { action_filters.size > 1 ? action_filters : action_filters.first }
   let(:format_filter) { :html }
   let(:format_filters) { Array.wrap(format_filter) }
-  let(:compose) { klazz.act_on_format(*format_filters, on: action_params) }
+  let(:compose) { klazz.respond_act_to(*format_filters, on: action_params) }
 end


### PR DESCRIPTION
Given #17 , we will change `#act_on_format` to be aligned with the rescue class method `#rescue_act_from`

`#respond_act_to` will be the core API and `#act_on_format` will be aliasing it from now onwards