### PR TITLE
fix: ensure validation message use #inspect 

### DIFF
--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -31,7 +31,7 @@ module MimeActor
       # @param rule the name of validator
       def validate!(rule, *args)
         validator = "validate_#{rule}"
-        raise NameError, "Validator not found, got: #{validator}" unless respond_to?(validator, true)
+        raise NameError, "Validator not found, got: #{validator.inspect}" unless respond_to?(validator, true)
 
         error = send(validator, *args)
         raise error if error
@@ -49,7 +49,7 @@ module MimeActor
       # @param unchecked the `actions` to be validated
       def validate_actions(unchecked)
         rejected = unchecked.reject { |action| action.is_a?(Symbol) }
-        NameError.new("invalid actions, got: #{rejected.join(", ")}") if rejected.size.positive?
+        NameError.new("invalid actions, got: #{rejected.map(&:inspect).join(", ")}") if rejected.size.positive?
       end
 
       # Validate `format` must be a Symbol and a valid MIME type
@@ -58,7 +58,7 @@ module MimeActor
       def validate_format(unchecked)
         return ArgumentError.new("format must be a Symbol") unless unchecked.is_a?(Symbol)
 
-        NameError.new("invalid format, got: #{unchecked}") unless scene_formats.include?(unchecked)
+        NameError.new("invalid format, got: #{unchecked.inspect}") unless scene_formats.include?(unchecked)
       end
 
       # Validate `formats` must be an collection of Symbol which each of them is a valid MIME type
@@ -69,7 +69,7 @@ module MimeActor
         filtered = unfiltered & scene_formats
         rejected = unfiltered - filtered
 
-        NameError.new("invalid formats, got: #{rejected.join(", ")}") if rejected.size.positive?
+        NameError.new("invalid formats, got: #{rejected.map(&:inspect).join(", ")}") if rejected.size.positive?
       end
 
       # Validate `klazz` must be a Class/Module or a String referencing a Class/Module

--- a/spec/mime_actor/rescue_spec.rb
+++ b/spec/mime_actor/rescue_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe MimeActor::Rescue do
         it_behaves_like "rescuable format filter", "Array of String", acceptance: false do
           let(:format_filters) { %w[json html] }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid formats, got: json, html" }
+          let(:error_message_raised) { "invalid formats, got: \"json\", \"html\"" }
         end
         it_behaves_like "rescuable format filter", "Array of Symbol/String", acceptance: false do
           let(:format_filters) { [:json, "html"] }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid formats, got: html" }
+          let(:error_message_raised) { "invalid formats, got: \"html\"" }
         end
       end
 
@@ -72,12 +72,12 @@ RSpec.describe MimeActor::Rescue do
         it_behaves_like "rescuable format filter", "Symbol", acceptance: false do
           let(:format_filter) { :my_json }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid format, got: my_json" }
+          let(:error_message_raised) { "invalid format, got: :my_json" }
         end
         it_behaves_like "rescuable format filter", "Array of Symbol", acceptance: false do
           let(:format_filters) { %i[json my_json html my_html] }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid formats, got: my_json, my_html" }
+          let(:error_message_raised) { "invalid formats, got: :my_json, :my_html" }
         end
         it_behaves_like "rescuable format filter", "String", acceptance: false do
           let(:format_filter) { "my_json" }
@@ -85,12 +85,12 @@ RSpec.describe MimeActor::Rescue do
         it_behaves_like "rescuable format filter", "Array of String", acceptance: false do
           let(:format_filters) { %w[json my_json html my_html] }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid formats, got: json, my_json, html, my_html" }
+          let(:error_message_raised) { "invalid formats, got: \"json\", \"my_json\", \"html\", \"my_html\"" }
         end
         it_behaves_like "rescuable format filter", "Array of Symbol/String", acceptance: false do
           let(:format_filters) { [:json, :my_json, "html", "my_html"] }
           let(:error_class_raised) { NameError }
-          let(:error_message_raised) { "invalid formats, got: my_json, html, my_html" }
+          let(:error_message_raised) { "invalid formats, got: :my_json, \"html\", \"my_html\"" }
         end
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe MimeActor::Rescue do
       it_behaves_like "rescuable action filter", "Array of String", acceptance: false do
         let(:action_filters) { %w[debug load] }
         let(:error_class_raised) { NameError }
-        let(:error_message_raised) { "invalid actions, got: debug, load" }
+        let(:error_message_raised) { "invalid actions, got: \"debug\", \"load\"" }
       end
     end
 

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe MimeActor::Scene do
       it_behaves_like "composable scene action", "Array of String", acceptance: false do
         let(:action_filters) { %w[index create] }
         let(:error_class_raised) { NameError }
-        let(:error_message_raised) { "invalid actions, got: index, create" }
+        let(:error_message_raised) { "invalid actions, got: \"index\", \"create\"" }
       end
       it_behaves_like "composable scene action", "Array of String/Symbol", acceptance: false do
         let(:action_filters) { [:index, "create"] }
         let(:error_class_raised) { NameError }
-        let(:error_message_raised) { "invalid actions, got: create" }
+        let(:error_message_raised) { "invalid actions, got: \"create\"" }
       end
       it_behaves_like "composable scene action", "#new" do
         let(:action_filter) { :new }


### PR DESCRIPTION
Ensure validation message use `#inspect` to describe invalid values.

allow developer to understand the class type of the invalid values