### PR TITLE
fix: require active support `nil` class extension

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -8,6 +8,7 @@ require "mime_actor/validator"
 require "active_support/concern"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/inflections"
 
 module MimeActor

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -3,6 +3,7 @@
 # :markup: markdown
 
 require "active_support/concern"
+require "active_support/core_ext/object/blank"
 require "set" # required by mime_type with ruby <= 3.1
 require "action_dispatch/http/mime_type"
 


### PR DESCRIPTION
 Ensure using `#present?` on `nil` works via active support