### PR TITLE
fix: switch back to ClassMethods

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -29,7 +29,7 @@ module MimeActor
       mattr_accessor :actor_rescuers, instance_writer: false, default: []
     end
 
-    class_methods do
+    module ClassMethods
       # Registers a rescue handler for the given error classes with `action`/`format` filter
       #
       # @param klazzes the error classes to rescue
@@ -91,9 +91,7 @@ module MimeActor
         end
       end
 
-      private
-
-      def dispatch_rescuer(error, format:, action:, context:)
+      private def dispatch_rescuer(error, format:, action:, context:)
         case rescuer = find_rescuer(error, format:, action:)
         when Symbol
           rescuer_method = context.method(rescuer)
@@ -121,7 +119,7 @@ module MimeActor
         end
       end
 
-      def find_rescuer(error, format:, action:)
+      private def find_rescuer(error, format:, action:)
         return unless error
 
         *_, rescuer = actor_rescuers.reverse_each.detect do |rescuee, format_filter, action_filter|
@@ -134,7 +132,7 @@ module MimeActor
         rescuer
       end
 
-      def constantize_rescuee(class_or_name)
+      private def constantize_rescuee(class_or_name)
         case class_or_name
         when String, Symbol
           begin

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -31,7 +31,7 @@ module MimeActor
       mattr_accessor :acting_scenes, instance_writer: false, default: {}
     end
 
-    class_methods do
+    module ClassMethods
       # Register `action` + `format` definitions.
       #
       # @param formats the collection of `format`
@@ -62,9 +62,7 @@ module MimeActor
 
       alias_method :act_on_format, :respond_act_to
 
-      private
-
-      def compose_scene(action, format)
+      private def compose_scene(action, format)
         action_defined = (instance_methods + private_instance_methods).include?(action.to_sym)
         raise MimeActor::ActionExisted, action if !acting_scenes.key?(action) && action_defined
 
@@ -74,7 +72,7 @@ module MimeActor
         define_scene(action) unless action_defined
       end
 
-      def define_scene(action)
+      private def define_scene(action)
         class_eval(
           # def index
           #   self.respond_to?(:start_scene) && self.start_scene(:index)

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -22,7 +22,7 @@ module MimeActor
       mattr_accessor :raise_on_missing_actor, instance_writer: false, default: false
     end
 
-    class_methods do
+    module ClassMethods
       # Determine if the `actor_name` belongs to a public instance method excluding methods inherited from ancestors
       #
       # @param actor_name

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -26,7 +26,7 @@ module MimeActor
       mattr_accessor :scene_formats, instance_writer: false, default: Mime::SET.symbols.to_set
     end
 
-    class_methods do
+    module ClassMethods
       # Raise the error returned by validator if any.
       #
       # @param rule the name of validator


### PR DESCRIPTION
switch back to ruby original public + private class methods definitions.

partly due to yard doc unable to parse dynamic module/class definitions without installing plugins