### PR TITLE
fix: error message should use `#inspect` for param

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -47,7 +47,7 @@ module MimeActor
       formats = acting_scenes.fetch(action, Set.new)
 
       if formats.empty?
-        logger.warn { "format is empty for action :#{action}" }
+        logger.warn { "format is empty for action #{action.inspect}" }
         return
       end
 

--- a/lib/mime_actor/errors.rb
+++ b/lib/mime_actor/errors.rb
@@ -24,7 +24,7 @@ module MimeActor
 
   class ActorNotFound < ActorError
     def generate_message
-      ":#{actor} not found"
+      "#{actor.inspect} not found"
     end
   end
 
@@ -39,7 +39,7 @@ module MimeActor
 
   class ActionExisted < ActionError
     def generate_message
-      "action :#{action} already existed"
+      "action #{action.inspect} already existed"
     end
   end
 end

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -72,7 +72,7 @@ module MimeActor
       unless self.class.actor?(actor_name)
         raise MimeActor::ActorNotFound, actor_name if raise_on_missing_actor
 
-        logger.warn { "actor not found, expected :#{actor_name}" }
+        logger.warn { "actor #{actor_name.inspect} not found" }
         return
       end
 

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ActionController::Metal do
       allow(stub_logger).to receive(:warn)
       expect { dispatch }.not_to raise_error
       expect(stub_logger).to have_received(:warn) do |&block|
-        expect(block.call).to eq "actor not found, expected: \"new_json\""
+        expect(block.call).to eq "actor \"new_json\" not found"
       end
     end
 

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -54,17 +54,17 @@ RSpec.describe ActionController::Metal do
       allow(stub_logger).to receive(:warn)
       expect { dispatch }.not_to raise_error
       expect(stub_logger).to have_received(:warn) do |&block|
-        expect(block.call).to eq "actor not found, expected :new_json"
+        expect(block.call).to eq "actor not found, expected: \"new_json\""
       end
     end
 
     context "when raise_on_missing_actor is set" do
       before { controller_class.raise_on_missing_actor = true }
 
-      it "raises error" do
+      it "raises #{MimeActor::ActorNotFound}" do
         expect(controller_class.action_methods).not_to include(action_actor)
         expect(controller_class).not_to be_method_defined(action_actor)
-        expect { dispatch }.to raise_error(MimeActor::ActorNotFound, ":new_json not found")
+        expect { dispatch }.to raise_error(MimeActor::ActorNotFound, "\"new_json\" not found")
       end
     end
   end

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe MimeActor::Stage do
       it "logs a warning message" do
         expect(cue).to be_nil
         expect(stub_logger).to have_received(:warn) do |&block|
-          expect(block.call).to eq "actor not found, expected :unknown_actor"
+          expect(block.call).to eq "actor :unknown_actor not found"
         end
       end
 

--- a/spec/support/shared_examples/shared_examples_for_rescue.rb
+++ b/spec/support/shared_examples/shared_examples_for_rescue.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/array/wrap"
-
 RSpec.shared_examples "rescuable error filter" do |error_name, acceptance: true|
   include_context "with rescuable filter"
 

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/array/wrap"
-
 RSpec.shared_examples "composable scene action" do |action_name, acceptance: true|
   include_context "with scene composition"
 


### PR DESCRIPTION
error/log message with `#inspect` when param is included