### PR TITLE
feat: actor responder

### DIFF
--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -18,10 +18,22 @@ module MimeActor
   #
   # @example register a `html` format on action `index`
   #   respond_act_to :html, on: :index
+  #
+  #   # this method should be defined in the class
+  #   def index_html; end
   # @example register `html`, `json` formats on actions `index`, `show`
   #   respond_act_to :html, :json , on: [:index, :show]
+  #
+  #   # these methods should be defined in the class
+  #   def index_html; end
+  #   def index_json; end
+  #   def show_html; end
+  #   def show_json; end
   # @example register a `html` format on action `index` with respond handler method
   #   respond_act_to :html, on: :index, with: :render_html
+  #
+  #   # this method should be defined in the class
+  #   def render_html; end
   # @example register a `html` format on action `index` with respond handler proc
   #   respond_act_to :html, on: :index do
   #     render :index
@@ -48,10 +60,22 @@ module MimeActor
       #
       # @example register a `html` format on action `index`
       #   respond_act_to :html, on: :index
+      #
+      #   # this method should be defined in the class
+      #   def index_html; end
       # @example register `html`, `json` formats on actions `index`, `show`
       #   respond_act_to :html, :json , on: [:index, :show]
+      #
+      #   # these methods should be defined in the class
+      #   def index_html; end
+      #   def index_json; end
+      #   def show_html; end
+      #   def show_json; end
       # @example register a `html` format on action `index` with respond handler method
       #   respond_act_to :html, on: :index, with: :render_html
+      #
+      #   # this method should be defined in the class
+      #   def render_html; end
       # @example register a `html` format on action `index` with respond handler proc
       #   respond_act_to :html, on: :index do
       #     render :index

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -61,6 +61,8 @@ module MimeActor
       def respond_act_to(*formats, on: nil, with: nil, &block)
         validate!(:formats, formats)
 
+        raise ArgumentError, "provide either the with: argument or a block" if with.present? && block_given?
+
         if block_given?
           with = block
         elsif with.present?

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MimeActor::Action do
       it "logs missing formats" do
         expect { start }.not_to raise_error
         expect(stub_logger).to have_received(:warn) do |&block|
-          expect(block.call).to eq "format is empty for action :create"
+          expect(block.call).to eq "format is empty for action: :create"
         end
       end
     end

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -80,26 +80,64 @@ RSpec.describe MimeActor::Scene do
       end
     end
 
+    describe "#with" do
+      describe "when block is not given" do
+        let(:compose) { klazz.respond_act_to :html, on: :create }
+
+        it "optional" do
+          expect { compose }.not_to raise_error
+        end
+      end
+
+      describe "when block is given" do
+        let(:compose) do
+          klazz.respond_act_to :html, on: :create, with: proc {} do
+            "test"
+          end
+        end
+
+        it "must be absent" do
+          expect { compose }.to raise_error(ArgumentError, "provide either the with: argument or a block")
+        end
+      end
+
+      it_behaves_like "composable scene with handler", "Proc", Proc do
+        let(:handler) { proc {} }
+      end
+      it_behaves_like "composable scene with handler", "Lambda", Proc do
+        let(:handler) { -> {} }
+      end
+      it_behaves_like "composable scene with handler", "Symbol", Symbol do
+        let(:handler) { :custom_handler }
+      end
+      it_behaves_like "composable scene with handler", "String", String, acceptance: false do
+        let(:handler) { "custom_handler" }
+      end
+      it_behaves_like "composable scene with handler", "Method", Method, acceptance: false do
+        let(:handler) { method(:to_s) }
+      end
+    end
+
     describe "when is called multiple times" do
       it "merges the scenes" do
         expect(klazz.acting_scenes).to be_empty
         klazz.respond_act_to(:html, on: %i[index create])
         expect(klazz.acting_scenes).to include(
-          index:  Set[:html],
-          create: Set[:html]
+          index:  { html: anything },
+          create: { html: anything }
         )
         klazz.respond_act_to(:xml, on: %i[create update])
         expect(klazz.acting_scenes).to include(
-          index:  Set[:html],
-          create: Set[:html, :xml],
-          update: Set[:xml]
+          index:  { html: anything },
+          create: { html: anything, xml: anything },
+          update: { xml: anything }
         )
         klazz.respond_act_to(:json, :xml, on: %i[create show])
         expect(klazz.acting_scenes).to include(
-          index:  Set[:html],
-          create: Set[:html, :xml, :json],
-          update: Set[:xml],
-          show:   Set[:json, :xml]
+          index:  { html: anything },
+          create: { html: anything, xml: anything, json: anything },
+          update: { xml: anything },
+          show:   { json: anything, xml: anything }
         )
       end
     end

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -90,11 +90,8 @@ RSpec.describe MimeActor::Scene do
       end
 
       describe "when block is given" do
-        let(:compose) do
-          klazz.respond_act_to :html, on: :create, with: proc {} do
-            "test"
-          end
-        end
+        let(:empty_block) { proc {} }
+        let(:compose) { klazz.respond_act_to :html, on: :create, with: proc {}, &empty_block }
 
         it "must be absent" do
           expect { compose }.to raise_error(ArgumentError, "provide either the with: argument or a block")
@@ -115,6 +112,18 @@ RSpec.describe MimeActor::Scene do
       end
       it_behaves_like "composable scene with handler", "Method", Method, acceptance: false do
         let(:handler) { method(:to_s) }
+      end
+    end
+
+    describe "#block" do
+      let(:empty_block) { proc {} }
+      let(:compose) { klazz.respond_act_to :html, on: :show, &empty_block }
+
+      it "be the handler" do
+        expect(klazz.acting_scenes).to be_empty
+        expect { compose }.not_to raise_error
+        expect(klazz.acting_scenes).not_to be_empty
+        expect(klazz.acting_scenes).to include(show: { html: kind_of(Proc) })
       end
     end
 

--- a/spec/support/shared_context/shared_context_for_stage.rb
+++ b/spec/support/shared_context/shared_context_for_stage.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with stage cue" do
+  let(:klazz_instance) { klazz.new }
+  let(:acting_instructions) { [] }
+  let(:stub_logger) { instance_double(ActiveSupport::Logger) }
+  let(:cue) { klazz_instance.cue_actor(actor, *acting_instructions) }
+
+  before { klazz.config.logger = stub_logger }
+end

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "stage cue actor method" do |actor_method|
+  include_context "with stage cue"
+
+  let(:actor) { actor_method }
+
+  context "when actor method exists" do
+    context "with insturctions" do
+      let(:acting_instructions) { "overheard the news" }
+
+      before do
+        klazz.define_method(actor_method) do |scripts|
+          "shed tears of joy when #{scripts}"
+        end
+      end
+
+      it "returns result from actor" do
+        expect(cue).to eq "shed tears of joy when overheard the news"
+      end
+    end
+
+    context "without insturctions" do
+      before do
+        klazz.define_method(actor_method) { "a meaningless truth" }
+      end
+
+      it "returns result from actor" do
+        expect(cue).to eq "a meaningless truth"
+      end
+    end
+
+    context "with block passed" do
+      let(:cue) { klazz_instance.cue_actor(actor_method, *acting_instructions, &another_block) }
+      let(:another_block) { ->(num) { num**num } }
+
+      before do
+        klazz.define_method(actor_method) { 3 }
+      end
+
+      it "yield the block wih the result from actor" do
+        expect(cue).to eq 27
+      end
+    end
+  end
+
+  context "when actor method does not exist" do
+    before { allow(stub_logger).to receive(:warn).and_yield }
+
+    it "returns nil" do
+      expect(cue).to be_nil
+    end
+
+    it "logs a warning message" do
+      expect(cue).to be_nil
+      expect(stub_logger).to have_received(:warn) do |&block|
+        expect(block.call).to eq "actor #{actor_method.inspect} not found"
+      end
+    end
+
+    context "when raise_on_missing_actor is set" do
+      before { klazz.raise_on_missing_actor = true }
+
+      it "raises #{MimeActor::ActorNotFound}" do
+        expect { cue }.to raise_error(MimeActor::ActorNotFound, "#{actor_method.inspect} not found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #2 
closes #5 in favor of passing the specific actor name

allow `#repond_act_to` to accept `with` argument or a `block` in replace of the default `def <action>_<format>; end`

```rb
respond_act_to :html, on: :index
def index_html; end

respond_act_to :html, :json , on: [:index, :show]
def index_html; end
def index_json; end
def show_html; end
def show_json; end

respond_act_to :html, on: :index, with: :render_html
def render_html; end

respond_act_to :html, on: :index do
  render :index
end
```