### PR TITLE
fix: update type check logic to raise `TypeError` instead

### DIFF
--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -76,7 +76,7 @@ module MimeActor
                when Proc
                  actor_proc_call(actor, *args)
                else
-                 raise ArgumentError, "invalid actor, got: #{actor.inspect}"
+                 raise TypeError, "invalid actor, got: #{actor.inspect}"
                end
 
       if block_given?

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -42,7 +42,7 @@ module MimeActor
       #
       # @param unchecked the `action` to be validated
       def validate_action(unchecked)
-        ArgumentError.new("action must be a Symbol") unless unchecked.is_a?(Symbol)
+        TypeError.new("action must be a Symbol") unless unchecked.is_a?(Symbol)
       end
 
       # Validate `actions` must be a collection of Symbol
@@ -57,7 +57,7 @@ module MimeActor
       #
       # @param unchecked the `format` to be validated
       def validate_format(unchecked)
-        return ArgumentError.new("format must be a Symbol") unless unchecked.is_a?(Symbol)
+        return TypeError.new("format must be a Symbol") unless unchecked.is_a?(Symbol)
 
         NameError.new("invalid format, got: #{unchecked.inspect}") unless scene_formats.include?(unchecked)
       end
@@ -79,7 +79,7 @@ module MimeActor
       def validate_klazz(unchecked)
         return if unchecked.is_a?(Module) || unchecked.is_a?(String)
 
-        ArgumentError.new("#{unchecked.inspect} must be a Class/Module or a String referencing a Class/Module")
+        TypeError.new("#{unchecked.inspect} must be a Class/Module or a String referencing a Class/Module")
       end
 
       # Validate `with` must be a Symbol or Proc
@@ -88,7 +88,7 @@ module MimeActor
       def validate_with(unchecked)
         return if unchecked.is_a?(Proc) || unchecked.is_a?(Symbol)
 
-        ArgumentError.new("with handler must be a Symbol or Proc, got: #{unchecked.inspect}")
+        TypeError.new("with handler must be a Symbol or Proc, got: #{unchecked.inspect}")
       end
     end
   end

--- a/spec/mime_actor/rescue_spec.rb
+++ b/spec/mime_actor/rescue_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe MimeActor::Rescue do
       end
       it_behaves_like "rescuable error filter", "Integer", acceptance: false do
         let(:error_filter) { 100 }
+        let(:error_class_raised) { TypeError }
         let(:error_message_raised) { "100 must be a Class/Module or a String referencing a Class/Module" }
       end
     end
@@ -55,6 +56,8 @@ RSpec.describe MimeActor::Rescue do
         end
         it_behaves_like "rescuable format filter", "String", acceptance: false do
           let(:format_filter) { "json" }
+          let(:error_class_raised) { TypeError }
+          let(:error_message_raised) { "format must be a Symbol" }
         end
         it_behaves_like "rescuable format filter", "Array of String", acceptance: false do
           let(:format_filters) { %w[json html] }
@@ -81,6 +84,8 @@ RSpec.describe MimeActor::Rescue do
         end
         it_behaves_like "rescuable format filter", "String", acceptance: false do
           let(:format_filter) { "my_json" }
+          let(:error_class_raised) { TypeError }
+          let(:error_message_raised) { "format must be a Symbol" }
         end
         it_behaves_like "rescuable format filter", "Array of String", acceptance: false do
           let(:format_filters) { %w[json my_json html my_html] }
@@ -104,6 +109,8 @@ RSpec.describe MimeActor::Rescue do
       end
       it_behaves_like "rescuable action filter", "String", acceptance: false do
         let(:action_filter) { "index" }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "action must be a Symbol" }
       end
       it_behaves_like "rescuable action filter", "Array of String", acceptance: false do
         let(:action_filters) { %w[debug load] }
@@ -144,9 +151,13 @@ RSpec.describe MimeActor::Rescue do
       end
       it_behaves_like "rescuable with handler", "String", String, acceptance: false do
         let(:handler) { "custom_handler" }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
       end
       it_behaves_like "rescuable with handler", "Method", Method, acceptance: false do
         let(:handler) { method(:to_s) }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
       end
     end
 
@@ -348,7 +359,7 @@ RSpec.describe MimeActor::Rescue do
         klazz.actor_rescuers << [123, nil, nil, proc {}]
       end
 
-      it "raise error" do
+      it "raise #{TypeError}" do
         expect { rescuable }.to raise_error(TypeError, "class or module required")
       end
     end

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe MimeActor::Scene do
     describe "#action" do
       it_behaves_like "composable scene action", "nil", acceptance: false do
         let(:action_filter) { nil }
+        let(:error_class_raised) { ArgumentError }
         let(:error_message_raised) { "action is required" }
       end
       it_behaves_like "composable scene action", "Symbol" do
@@ -27,6 +28,8 @@ RSpec.describe MimeActor::Scene do
       end
       it_behaves_like "composable scene action", "String", acceptance: false do
         let(:action_filter) { "create" }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "action must be a Symbol" }
       end
       it_behaves_like "composable scene action", "Array of String", acceptance: false do
         let(:action_filters) { %w[index create] }
@@ -55,9 +58,13 @@ RSpec.describe MimeActor::Scene do
     describe "unsupported format" do
       it_behaves_like "composable scene format", "Symbol", acceptance: false do
         let(:format_filter) { :my_custom }
+        let(:error_class_raised) { NameError }
+        let(:error_message_raised) { "invalid formats, got: :my_custom" }
       end
       it_behaves_like "composable scene format", "Array of Symbol", acceptance: false do
         let(:format_filters) { %i[html my_custom xml] }
+        let(:error_class_raised) { NameError }
+        let(:error_message_raised) { "invalid formats, got: :my_custom" }
       end
     end
 
@@ -109,9 +116,13 @@ RSpec.describe MimeActor::Scene do
       end
       it_behaves_like "composable scene with handler", "String", String, acceptance: false do
         let(:handler) { "custom_handler" }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
       end
       it_behaves_like "composable scene with handler", "Method", Method, acceptance: false do
         let(:handler) { method(:to_s) }
+        let(:error_class_raised) { TypeError }
+        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
       end
     end
 

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe MimeActor::Stage do
       include_context "with stage cue"
       let(:actor) { 200 }
 
-      it "raises #{ArgumentError}" do
-        expect { cue }.to raise_error(ArgumentError, "invalid actor, got: 200")
+      it "raises #{TypeError}" do
+        expect { cue }.to raise_error(TypeError, "invalid actor, got: 200")
       end
     end
 

--- a/spec/support/shared_examples/shared_examples_for_rescue.rb
+++ b/spec/support/shared_examples/shared_examples_for_rescue.rb
@@ -13,9 +13,6 @@ RSpec.shared_examples "rescuable error filter" do |error_name, acceptance: true|
       end
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { "" }
-
     it "rejects #{error_name || "the error"}" do
       expect { rescuable }.to raise_error(error_class_raised, error_message_raised)
       expect(klazz.actor_rescuers).to be_empty
@@ -34,9 +31,6 @@ RSpec.shared_examples "rescuable format filter" do |format_name, acceptance: tru
       end
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { "format must be a Symbol" }
-
     it "rejects #{format_name || "the format"}" do
       expect { rescuable }.to raise_error(error_class_raised, error_message_raised)
       expect(klazz.actor_rescuers).to be_empty
@@ -53,9 +47,6 @@ RSpec.shared_examples "rescuable action filter" do |action_name, acceptance: tru
       expect(klazz.actor_rescuers).to include(["StandardError", nil, action_params, kind_of(Symbol)])
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { "action must be a Symbol" }
-
     it "accepts #{action_name || "the format"}" do
       expect { rescuable }.to raise_error(error_class_raised, error_message_raised)
       expect(klazz.actor_rescuers).to be_empty
@@ -72,9 +63,6 @@ RSpec.shared_examples "rescuable with handler" do |handler_name, handler_type, a
       expect(klazz.actor_rescuers).to include(["StandardError", nil, nil, kind_of(handler_type)])
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { /with handler must be a Symbol or Proc, got:/ }
-
     it "rejects #{handler_name || "the handler"}" do
       expect { rescuable }.to raise_error(error_class_raised, error_message_raised)
       expect(klazz.actor_rescuers).to be_empty

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -11,9 +11,6 @@ RSpec.shared_examples "composable scene action" do |action_name, acceptance: tru
       expect(klazz.acting_scenes.keys).to match_array(action_filters)
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { "action must be a Symbol" }
-
     it "rejects #{action_name || "the action"}" do
       expect(klazz.acting_scenes).to be_empty
       expect { compose }.to raise_error(error_class_raised, error_message_raised)
@@ -33,9 +30,6 @@ RSpec.shared_examples "composable scene format" do |format_name, acceptance: tru
       expect(klazz.acting_scenes.values.flat_map(&:keys)).to match_array(format_filters)
     end
   else
-    let(:error_class_raised) { NameError }
-    let(:error_message_raised) { /invalid formats, got:/ }
-
     it "rejects #{format_name || "the format"}" do
       expect(klazz.acting_scenes).to be_empty
       expect { compose }.to raise_error(error_class_raised, error_message_raised)
@@ -67,9 +61,6 @@ RSpec.shared_examples "composable scene with handler" do |handler_name, handler_
       expect(klazz.acting_scenes).to include expected_scenes
     end
   else
-    let(:error_class_raised) { ArgumentError }
-    let(:error_message_raised) { /with handler must be a Symbol or Proc, got:/ }
-
     it "rejects #{handler_name || "the handler"}" do
       expect(klazz.acting_scenes).to be_empty
       expect { compose }.to raise_error(error_class_raised, error_message_raised)


### PR DESCRIPTION
update type check logic to raise `TypeError` instead.

- arg absence will raise `ArgumentError`
- unsupported arg type will raise `TypeError`
- unsupported arg value will raise `NameType`