### PR TITLE
fix: ensure `actor` passed to `#cue_actor` is executed within the instance

### DIFF
--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -101,7 +101,7 @@ module MimeActor
 
     def actor_proc_call(actor_proc, *args)
       passable_args = actor_proc.arity.negative? ? args : args.take(actor_proc.arity)
-      actor_proc.call(*passable_args)
+      instance_exec(*passable_args, &actor_proc)
     end
   end
 end

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe MimeActor::Stage do
 
     describe "when actor is Proc" do
       include_context "with stage cue"
+
+      let(:actor) { -> { equal?(1) } }
+
+      it "evaluate with context" do
+        allow(klazz_instance).to receive(:equal?).and_return(true)
+        expect(cue).to be_truthy
+        expect(klazz_instance).to have_received(:equal?).with(1)
+      end
+
       context "with instructions" do
         let(:actor) { ->(scripts) { "shed tears of joy when #{scripts}" } }
         let(:acting_instructions) { "saw the news" }


### PR DESCRIPTION
ensure `actor` passed to `#cue_actor` is executed within the instance