### PR TITLE
fix: use `module_eval` inside module

### DIFF
--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -122,7 +122,7 @@ module MimeActor
       end
 
       def define_scene(action)
-        class_eval(
+        module_eval(
           # def index
           #   self.respond_to?(:start_scene) && self.start_scene(:index)
           # end


### PR DESCRIPTION
given that `class_eval` is an alias of `module_eval`, we will switch to `module_eval` in a module