### PR TITLE
refactor: dispatcher call

### DIFF
--- a/lib/mime_actor/dispatcher.rb
+++ b/lib/mime_actor/dispatcher.rb
@@ -5,32 +5,50 @@
 module MimeActor
   module Dispatcher
     class MethodCall
+      attr_reader :method_name, :args
+
       def initialize(method_name, *args)
         @method_name = method_name
         @args = args
+        validate!
       end
 
       def to_callable
         lambda do |target|
-          throw :abort, @method_name unless target.respond_to?(@method_name)
-          method_call = target.method(@method_name)
-          filtered_args = method_call.arity.negative? ? @args : @args.take(method_call.arity)
+          throw :abort, method_name unless target.respond_to?(method_name)
+          method_call = target.method(method_name)
+          filtered_args = method_call.arity.negative? ? args : args.take(method_call.arity)
           method_call.call(*filtered_args)
         end
+      end
+
+      private
+
+      def validate!
+        raise ArgumentError, "invalid method name: #{method_name.inspect}" unless method_name in String | Symbol
       end
     end
 
     class InstanceExec
-      def initialize(proc, *args)
-        @proc = proc
+      attr_reader :block, :args
+
+      def initialize(block, *args)
+        @block = block
         @args = args
+        validate!
       end
 
       def to_callable
         lambda do |target|
-          filtered_args = @proc.arity.negative? ? @args : @args.take(@proc.arity)
-          target.instance_exec(*filtered_args, &@proc)
+          filtered_args = block.arity.negative? ? args : args.take(block.arity)
+          target.instance_exec(*filtered_args, &block)
         end
+      end
+
+      private
+
+      def validate!
+        raise ArgumentError, "invalid block: #{block.inspect}" unless block in Proc
       end
     end
 

--- a/lib/mime_actor/dispatcher.rb
+++ b/lib/mime_actor/dispatcher.rb
@@ -12,7 +12,7 @@ module MimeActor
 
       def to_callable
         lambda do |target|
-          throw :abort, MimeActor::ActorNotFound.new(@method_name) unless target.respond_to?(@method_name)
+          throw :abort, @method_name unless target.respond_to?(@method_name)
           method_call = target.method(@method_name)
           filtered_args = method_call.arity.negative? ? @args : @args.take(method_call.arity)
           method_call.call(*filtered_args)

--- a/lib/mime_actor/dispatcher.rb
+++ b/lib/mime_actor/dispatcher.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module MimeActor
+  module Dispatcher
+    class MethodCall
+      def initialize(method_name, *args)
+        @method_name = method_name
+        @args = args
+      end
+
+      def to_callable
+        lambda do |target|
+          throw :abort, MimeActor::ActorNotFound.new(@method_name) unless target.respond_to?(@method_name)
+          method_call = target.method(@method_name)
+          filtered_args = method_call.arity.negative? ? @args : @args.take(method_call.arity)
+          method_call.call(*filtered_args)
+        end
+      end
+    end
+
+    class InstanceExec
+      def initialize(proc, *args)
+        @proc = proc
+        @args = args
+      end
+
+      def to_callable
+        lambda do |target|
+          filtered_args = @proc.arity.negative? ? @args : @args.take(@proc.arity)
+          target.instance_exec(*filtered_args, &@proc)
+        end
+      end
+    end
+
+    def self.build(callable, *args)
+      case callable
+      when String, Symbol
+        MethodCall.new(callable, *args)
+      when Proc
+        InstanceExec.new(callable, *args)
+      end
+    end
+  end
+end

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -75,7 +75,9 @@ module MimeActor
     #
     # NOTE: method call on actor if it is String or Symbol. Proc#call if actor is Proc
     #
-    # @param actor either a method name or a block to evaluate
+    # @param actor either a method name or a Proc to evaluate
+    # @param args arguments to be passed when calling the actor
+    #
     def cue_actor(actor, *args)
       dispatch = MimeActor::Dispatcher.build(actor, *args)
       raise TypeError, "invalid actor, got: #{actor.inspect}" unless dispatch

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -104,21 +104,5 @@ module MimeActor
 
       logger.error { "actor error, cause: #{error.inspect}" }
     end
-
-    def actor_method_call(actor_method, *args)
-      unless self.class.actor?(actor_method)
-        raise MimeActor::ActorNotFound, actor_method if raise_on_actor_error
-
-        logger.warn { "actor #{actor_method.inspect} not found" }
-        return
-      end
-
-      public_send(actor_method, *args)
-    end
-
-    def actor_proc_call(actor_proc, *args)
-      passable_args = actor_proc.arity.negative? ? args : args.take(actor_proc.arity)
-      instance_exec(*passable_args, &actor_proc)
-    end
   end
 end

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -19,7 +19,7 @@ module MimeActor
     include Logging
 
     included do
-      mattr_accessor :raise_on_missing_actor, instance_writer: false, default: false
+      mattr_accessor :raise_on_actor_error, instance_writer: false, default: false
     end
 
     module ClassMethods
@@ -96,7 +96,7 @@ module MimeActor
 
     def actor_method_call(actor_method, *args)
       unless self.class.actor?(actor_method)
-        raise MimeActor::ActorNotFound, actor_method if raise_on_missing_actor
+        raise MimeActor::ActorNotFound, actor_method if raise_on_actor_error
 
         logger.warn { "actor #{actor_method.inspect} not found" }
         return

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -95,11 +95,12 @@ module MimeActor
       result = catch(:abort) do
         dispatch.to_callable.call(self).tap { dispatched = true }
       end
-      handle_actor_error(result) if result.is_a?(MimeActor::Error)
+      handle_actor_error(result) unless dispatched
       result if dispatched
     end
 
-    def handle_actor_error(error)
+    def handle_actor_error(actor)
+      error = MimeActor::ActorNotFound.new(actor)
       raise error if raise_on_actor_error
 
       logger.error { "actor error, cause: #{error.inspect}" }

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe ActionController::Metal do
       end
     end
 
-    context "when raise_on_missing_actor is set" do
-      before { controller_class.raise_on_missing_actor = true }
+    context "when raise_on_actor_error is set" do
+      before { controller_class.raise_on_actor_error = true }
 
       it "raises #{MimeActor::ActorNotFound}" do
         expect(controller_class.action_methods).not_to include(action_actor)

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe ActionController::Metal do
       expect(controller_class.action_methods).not_to include(action_actor)
       expect(controller_class).not_to be_method_defined(action_actor)
 
-      allow(stub_logger).to receive(:warn)
+      allow(stub_logger).to receive(:error)
       expect { dispatch }.not_to raise_error
-      expect(stub_logger).to have_received(:warn) do |&block|
-        expect(block.call).to eq "actor \"new_json\" not found"
+      expect(stub_logger).to have_received(:error) do |&block|
+        expect(block.call).to eq "actor error, cause: <MimeActor::ActorNotFound> \"new_json\" not found"
       end
     end
 

--- a/spec/mime_actor/dispatcher_spec.rb
+++ b/spec/mime_actor/dispatcher_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "mime_actor/dispatcher"
+
+RSpec.describe MimeActor::Dispatcher do
+  describe "MethodCall" do
+    let(:dispatcher) { described_class::MethodCall }
+
+    context "when method name is String" do
+      let(:dispatch) { dispatcher.new("my_method") }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores method name" do
+        expect(dispatch.method_name).to eq "my_method"
+      end
+    end
+
+    context "when method name is Symbol" do
+      let(:dispatch) { dispatcher.new(:my_method) }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores method name" do
+        expect(dispatch.method_name).to eq :my_method
+      end
+    end
+
+    context "when method name is Integer" do
+      it "is invalid" do
+        expect { dispatcher.new(100) }.to raise_error(ArgumentError, "invalid method name: 100")
+      end
+    end
+
+    context "with args" do
+      let(:dispatch) { dispatcher.new(:my_method, 1, "a", :b) }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores args" do
+        expect(dispatch.args).to contain_exactly(1, "a", :b)
+      end
+    end
+
+    describe "#to_callable" do
+      let(:dispatch) { dispatcher.new(:my_method) }
+
+      it "requires target" do
+        expect { dispatch.to_callable.call }.to raise_error(
+          ArgumentError, %r{wrong number of arguments}
+        )
+      end
+
+      it "requires target responds to the method name" do
+        expect { dispatch.to_callable.call(:stub) }.to throw_symbol(:abort, :my_method)
+      end
+
+      it "returns callee result" do
+        expect(dispatcher.new(:to_s).to_callable.call(:my_symbol)).to eq "my_symbol"
+      end
+
+      context "with additional args" do
+        let(:dispatch) { dispatcher.new(:to_sym, "extra") }
+
+        it "truncates the args acceptable by method" do
+          expect(dispatch.to_callable.call("my_string")).to eq :my_string
+        end
+      end
+    end
+  end
+
+  describe "InstanceExec" do
+    let(:dispatcher) { described_class::InstanceExec }
+
+    context "when block is Proc" do
+      let(:dispatch) { dispatcher.new(proc { "something" }) }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores block" do
+        expect(dispatch.block).to be_a(Proc)
+      end
+    end
+
+    context "when block is Lambda" do
+      let(:dispatch) { dispatcher.new(-> { "something" }) }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores block" do
+        expect(dispatch.block).to be_a(Proc)
+      end
+    end
+
+    context "when block is String" do
+      it "is invalid" do
+        expect { dispatcher.new("my_proc") }.to raise_error(ArgumentError, "invalid block: \"my_proc\"")
+      end
+    end
+
+    context "with args" do
+      let(:dispatch) { dispatcher.new(proc { "something" }, 1, "a", :b) }
+
+      it "is valid" do
+        expect(dispatch).to be_a(dispatcher)
+      end
+
+      it "stores args" do
+        expect(dispatch.args).to contain_exactly(1, "a", :b)
+      end
+    end
+
+    describe "#to_callable" do
+      let(:dispatch) { dispatcher.new(proc { to_s }) }
+
+      it "requires target" do
+        expect { dispatch.to_callable.call }.to raise_error(
+          ArgumentError, %r{wrong number of arguments}
+        )
+      end
+
+      it "returns callee result" do
+        expect(dispatch.to_callable.call(:my_proc)).to eq "my_proc"
+      end
+
+      context "with additional args" do
+        let(:dispatch) { dispatcher.new(->(num) { "#{self} received #{num}" }, 11, "extra") }
+
+        it "truncates the args acceptable by method" do
+          expect(dispatch.to_callable.call(:my_lambda)).to eq "my_lambda received 11"
+        end
+      end
+    end
+  end
+
+  describe "#build" do
+    let(:dispatch) { described_class.build(callable) }
+
+    context "when callable is String" do
+      let(:callable) { "my_callable" }
+
+      it "returns MethodCall" do
+        expect(dispatch).to be_a(described_class::MethodCall)
+      end
+    end
+
+    context "when callable is Symbol" do
+      let(:callable) { :my_callable }
+
+      it "returns MethodCall" do
+        expect(dispatch).to be_a(described_class::MethodCall)
+      end
+    end
+
+    context "when callable is Proc" do
+      let(:callable) { proc { "something" } }
+
+      it "returns InstanceExec" do
+        expect(dispatch).to be_a(described_class::InstanceExec)
+      end
+    end
+
+    context "when callable is Lambda" do
+      let(:callable) { -> { "something" } }
+
+      it "returns InstanceExec" do
+        expect(dispatch).to be_a(described_class::InstanceExec)
+      end
+    end
+
+    context "when callable is not supported" do
+      let(:callable) { 1000 }
+
+      it "returns nil" do
+        expect(dispatch).to be_nil
+      end
+    end
+  end
+end

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -20,22 +20,22 @@ RSpec.describe MimeActor::Stage do
     end
   end
 
-  describe "#raise_on_missing_actor" do
+  describe "#raise_on_actor_error" do
     it "allows class attribute reader" do
-      expect(klazz.raise_on_missing_actor).to be_falsey
+      expect(klazz.raise_on_actor_error).to be_falsey
     end
 
     it "allows class attribute writter" do
-      expect { klazz.raise_on_missing_actor = true }.not_to raise_error
+      expect { klazz.raise_on_actor_error = true }.not_to raise_error
     end
 
     it "allows instance reader" do
-      expect(klazz.new.raise_on_missing_actor).to be_falsey
+      expect(klazz.new.raise_on_actor_error).to be_falsey
     end
 
     it "disallows instance writter" do
-      expect { klazz.new.raise_on_missing_actor = true }.to raise_error(
-        NoMethodError, %r{undefined method `raise_on_missing_actor='}
+      expect { klazz.new.raise_on_actor_error = true }.to raise_error(
+        NoMethodError, %r{undefined method `raise_on_actor_error='}
       )
     end
   end

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -58,8 +58,8 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
       end
     end
 
-    context "when raise_on_missing_actor is set" do
-      before { klazz.raise_on_missing_actor = true }
+    context "when raise_on_actor_error is set" do
+      before { klazz.raise_on_actor_error = true }
 
       it "raises #{MimeActor::ActorNotFound}" do
         expect { cue }.to raise_error(MimeActor::ActorNotFound, "#{actor_method.inspect} not found")

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -45,16 +45,16 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
   end
 
   context "when actor method does not exist" do
-    before { allow(stub_logger).to receive(:warn).and_yield }
+    before { allow(stub_logger).to receive(:error).and_yield }
 
     it "returns nil" do
       expect(cue).to be_nil
     end
 
-    it "logs a warning message" do
+    it "logs a error message" do
       expect(cue).to be_nil
-      expect(stub_logger).to have_received(:warn) do |&block|
-        expect(block.call).to eq "actor #{actor_method.inspect} not found"
+      expect(stub_logger).to have_received(:error) do |&block|
+        expect(block.call).to eq "actor error, cause: <MimeActor::ActorNotFound> #{actor_method.inspect} not found"
       end
     end
 


### PR DESCRIPTION
introduce dispatcher to wrap callee and args without passing context around which might be large object.