### PR TITLE
refactor: dispatcher callable API

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -154,11 +154,7 @@ module MimeActor
       visited << error
       rescuer = find_rescuer(error, format:, action:)
       if (dispatch = MimeActor::Dispatcher.build(rescuer, error, format, action))
-        dispatched = false
-        result = catch(:abort) do
-          dispatch.to_callable.call(self).tap { dispatched = true }
-        end
-        logger.error { "rescue error, cause: #{result.inspect}" } unless dispatched
+        dispatch.call(self)
         error
       elsif error&.cause
         rescue_actor(error.cause, format:, action:, visited:)

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -3,7 +3,6 @@
 # :markup: markdown
 
 require "mime_actor/dispatcher"
-require "mime_actor/errors"
 require "mime_actor/logging"
 require "mime_actor/rescue"
 
@@ -78,37 +77,21 @@ module MimeActor
     # @param args arguments to be passed when calling the actor
     #
     def cue_actor(actor, *args, action:, format:)
-      dispatch = MimeActor::Dispatcher.build(actor, *args)
-      raise TypeError, "invalid actor, got: #{actor.inspect}" unless dispatch
+      dispatcher = MimeActor::Dispatcher.build(actor, *args)
+      raise TypeError, "invalid actor, got: #{actor.inspect}" unless dispatcher
 
-      result = dispatch_actor(dispatch, action:, format:)
+      result = dispatcher.call(self)
       if block_given?
         yield result
       else
         result
       end
-    end
-
-    private
-
-    def dispatch_actor(dispatch, action:, format:)
-      dispatched = false
-      rescued = false
-      result = catch(:abort) do
-        dispatch.to_callable.call(self).tap { dispatched = true }
-      rescue StandardError => e
-        rescued = rescue_actor(e, action:, format:)
-        raise unless rescued
-      end
-      handle_actor_error(result) unless dispatched || rescued
-      result if dispatched
-    end
-
-    def handle_actor_error(actor)
-      error = MimeActor::ActorNotFound.new(actor)
-      raise error if raise_on_actor_error
-
-      logger.error { "actor error, cause: #{error.inspect}" }
+    rescue MimeActor::ActorNotFound => e
+      logger.error { "actor error, cause: #{e.inspect}" } unless raise_on_actor_error
+      raise e if raise_on_actor_error
+    rescue StandardError => e
+      rescued = rescue_actor(e, action:, format:)
+      rescued || raise
     end
   end
 end

--- a/spec/mime_actor/dispatcher_spec.rb
+++ b/spec/mime_actor/dispatcher_spec.rb
@@ -48,28 +48,28 @@ RSpec.describe MimeActor::Dispatcher do
       end
     end
 
-    describe "#to_callable" do
+    describe "#call" do
       let(:dispatch) { dispatcher.new(:my_method) }
 
       it "requires target" do
-        expect { dispatch.to_callable.call }.to raise_error(
+        expect { dispatch.call }.to raise_error(
           ArgumentError, %r{wrong number of arguments}
         )
       end
 
       it "requires target responds to the method name" do
-        expect { dispatch.to_callable.call(:stub) }.to throw_symbol(:abort, :my_method)
+        expect { dispatch.call(:stub) }.to raise_error(MimeActor::ActorNotFound, ":my_method not found")
       end
 
       it "returns callee result" do
-        expect(dispatcher.new(:to_s).to_callable.call(:my_symbol)).to eq "my_symbol"
+        expect(dispatcher.new(:to_s).call(:my_symbol)).to eq "my_symbol"
       end
 
       context "with additional args" do
         let(:dispatch) { dispatcher.new(:to_sym, "extra") }
 
         it "truncates the args acceptable by method" do
-          expect(dispatch.to_callable.call("my_string")).to eq :my_string
+          expect(dispatch.call("my_string")).to eq :my_string
         end
       end
     end
@@ -120,24 +120,24 @@ RSpec.describe MimeActor::Dispatcher do
       end
     end
 
-    describe "#to_callable" do
+    describe "#call" do
       let(:dispatch) { dispatcher.new(proc { to_s }) }
 
       it "requires target" do
-        expect { dispatch.to_callable.call }.to raise_error(
+        expect { dispatch.call }.to raise_error(
           ArgumentError, %r{wrong number of arguments}
         )
       end
 
       it "returns callee result" do
-        expect(dispatch.to_callable.call(:my_proc)).to eq "my_proc"
+        expect(dispatch.call(:my_proc)).to eq "my_proc"
       end
 
       context "with additional args" do
         let(:dispatch) { dispatcher.new(->(num) { "#{self} received #{num}" }, 11, "extra") }
 
         it "truncates the args acceptable by method" do
-          expect(dispatch.to_callable.call(:my_lambda)).to eq "my_lambda received 11"
+          expect(dispatch.call(:my_lambda)).to eq "my_lambda received 11"
         end
       end
     end

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
   let(:actor) { actor_method }
 
   context "when actor method exists" do
-    context "with insturctions" do
+    context "with instructions" do
       let(:acting_instructions) { "overheard the news" }
 
       before do
@@ -20,7 +20,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
       end
     end
 
-    context "without insturctions" do
+    context "without instructions" do
       before do
         klazz.define_method(actor_method) { "a meaningless truth" }
       end


### PR DESCRIPTION
- remove additional lambda wrapper when calling a dispatcher
- remove the same catch/throw scope located in different files, replaced with raise/rescue instead.