### PR TITLE
refactor: move action collection vs single action rule into a composed rule in validator

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -49,19 +49,11 @@ module MimeActor
         raise ArgumentError, "error filter is required" if klazzes.empty?
         raise ArgumentError, "provide either the with: argument or a block" unless with.present? ^ block_given?
 
-        if block_given?
-          with = block
-        else
-          validate!(:with, with)
-        end
+        validate!(:with, with) if with.present?
+        with = block if block_given?
 
-        if action.present?
-          action.is_a?(Enumerable) ? validate!(:actions, action) : validate!(:action, action)
-        end
-
-        if format.present?
-          format.is_a?(Enumerable) ? validate!(:formats, format) : validate!(:format, format)
-        end
+        validate!(:action_or_actions, action) if action.present?
+        validate!(:format_or_formats, format) if format.present?
 
         klazzes.each do |klazz|
           validate!(:klazz, klazz)

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -86,20 +86,12 @@ module MimeActor
 
         raise ArgumentError, "provide either the with: argument or a block" if with.present? && block_given?
 
-        if block_given?
-          with = block
-        elsif with.present?
-          validate!(:with, with)
-        end
+        validate!(:with, with) if with.present?
+        with = block if block_given?
 
-        case actions = on
-        when Enumerable
-          validate!(:actions, actions)
-        when Symbol, String
-          validate!(:action, actions)
-        else
-          raise ArgumentError, "action is required"
-        end
+        raise ArgumentError, "action is required" unless (actions = on).present?
+
+        validate!(:action_or_actions, actions)
 
         Array.wrap(actions).each do |action|
           formats.each { |format| compose_scene(action, format, with) }

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -53,6 +53,13 @@ module MimeActor
         NameError.new("invalid actions, got: #{rejected.map(&:inspect).join(", ")}") if rejected.size.positive?
       end
 
+      # Validate against `actions` rule if argument is a Enumerable. otherwise, validate against `action` rule.
+      #
+      # @param unchecked the `actions` or `action` to be validated
+      def validate_action_or_actions(unchecked)
+        unchecked.is_a?(Enumerable) ? validate_actions(unchecked) : validate_action(unchecked)
+      end
+
       # Validate `format` must be a Symbol and a valid MIME type
       #
       # @param unchecked the `format` to be validated
@@ -71,6 +78,13 @@ module MimeActor
         rejected = unfiltered - filtered
 
         NameError.new("invalid formats, got: #{rejected.map(&:inspect).join(", ")}") if rejected.size.positive?
+      end
+
+      # Validate against `formats` rule if argument is a Enumerable. otherwise, validate against `format` rule.
+      #
+      # @param unchecked the `formats` or `format` to be validated
+      def validate_format_or_formats(unchecked)
+        unchecked.is_a?(Enumerable) ? validate_formats(unchecked) : validate_format(unchecked)
       end
 
       # Validate `klazz` must be a Class/Module or a String referencing a Class/Module


### PR DESCRIPTION
create composed rules with OR logic for `action` and `format` rules