### PR TITLE
fix: support collection argument for  action/format filters in act_callacbks configuration

### DIFF
--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -68,15 +68,20 @@ module MimeActor
         define_callbacks name, skip_after_callbacks_if_terminated: true
       end
 
-      def configure_callbacks(callbacks, action, format, block)
-        chain = callback_chain_name(format)
-        define_callback_chain(chain)
-
+      def configure_callbacks(callbacks, actions, formats, block)
         options = {}
-        options[:if] = ActionMatcher.new(action) if action.present?
+        options[:if] = ActionMatcher.new(actions) if actions.present?
         callbacks.push(block) if block
+
+        formats = Array.wrap(formats)
+        formats << nil if formats.empty?
+
         callbacks.each do |callback|
-          yield chain, callback, options
+          formats.each do |format|
+            chain = callback_chain_name(format)
+            define_callback_chain(chain)
+            yield chain, callback, options
+          end
         end
       end
 

--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -80,35 +80,36 @@ module MimeActor
         end
       end
 
+      def validate_callback_options!(action, format)
+        validate!(:action_or_actions, action) if action.present?
+        validate!(:format_or_formats, format) if format.present?
+      end
+
       def define_act_callbacks(kind)
         module_eval(
           # def self.before_act(*callbacks, action: nil, format: nil, &block)
-          #   validate!(:action, action) if action.present?
-          #   validate!(:format, format) if format.present?
+          #   validate_callback_options!(action, format)
           #   configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
           #     set_callback(chain, :before, callback, options)
           #   end
           # end
           #
           # def self.prepend_before_act(*callbacks, action: nil, format: nil, &block)
-          #   validate!(:action, action) if action.present?
-          #   validate!(:format, format) if format.present?
+          #   validate_callback_options!(action, format)
           #   configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
           #     set_callback(chain, :before, callback, options.merge!(prepend: true))
           #   end
           # end
           <<-RUBY, __FILE__, __LINE__ + 1
             def self.#{kind}_act(*callbacks, action: nil, format: nil, &block)
-              validate!(:action, action) if action.present?
-              validate!(:format, format) if format.present?
+              validate_callback_options!(action, format)
               configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
                 set_callback(chain, :#{kind}, callback, options)
               end
             end
 
             def self.prepend_#{kind}_act(*callbacks, action: nil, format: nil, &block)
-              validate!(:action, action) if action.present?
-              validate!(:format, format) if format.present?
+              validate_callback_options!(action, format)
               configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
                 set_callback(chain, :#{kind}, callback, options.merge!(prepend: true))
               end

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -12,15 +12,23 @@ RSpec.describe MimeActor::Callbacks do
     it_behaves_like "runnable act callbacks action filter", kind, "Symbol" do
       let(:action_filter) { :show }
     end
+    it_behaves_like "runnable act callbacks action filter", kind, "Array of Symbol" do
+      let(:action_filter) { %i[show update] }
+    end
     it_behaves_like "runnable act callbacks action filter", kind, "String", acceptance: false do
       let(:action_filter) { "index" }
       let(:error_class_raised) { TypeError }
       let(:error_message_raised) { "action must be a Symbol" }
     end
-    it_behaves_like "runnable act callbacks action filter", kind, "Enumerable", acceptance: false do
-      let(:action_filter) { %i[index update] }
-      let(:error_class_raised) { TypeError }
-      let(:error_message_raised) { "action must be a Symbol" }
+    it_behaves_like "runnable act callbacks action filter", kind, "Array of String", acceptance: false do
+      let(:action_filter) { %w[index update] }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid actions, got: \"index\", \"update\"" }
+    end
+    it_behaves_like "runnable act callbacks action filter", kind, "Array of String/Symbol", acceptance: false do
+      let(:action_filter) { [:index, "update"] }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid actions, got: \"update\"" }
     end
 
     it_behaves_like "runnable act callbacks format filter", kind, "Nil" do
@@ -29,20 +37,33 @@ RSpec.describe MimeActor::Callbacks do
     it_behaves_like "runnable act callbacks format filter", kind, "Symbol" do
       let(:format_filter) { :html }
     end
+    it_behaves_like "runnable act callbacks format filter", kind, "Array of Symbol" do
+      let(:format_filter) { %i[html json] }
+    end
     it_behaves_like "runnable act callbacks format filter", kind, "Unsupported format", acceptance: false do
       let(:format_filter) { :something }
       let(:error_class_raised) { NameError }
       let(:error_message_raised) { "invalid format, got: :something" }
+    end
+    it_behaves_like "runnable act callbacks format filter", kind, "Array of Unsupported format", acceptance: false do
+      let(:format_filter) { %i[html something json] }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid formats, got: :something" }
     end
     it_behaves_like "runnable act callbacks format filter", kind, "String", acceptance: false do
       let(:format_filter) { "json" }
       let(:error_class_raised) { TypeError }
       let(:error_message_raised) { "format must be a Symbol" }
     end
-    it_behaves_like "runnable act callbacks format filter", kind, "Enumerable", acceptance: false do
-      let(:format_filter) { %i[html json] }
-      let(:error_class_raised) { TypeError }
-      let(:error_message_raised) { "format must be a Symbol" }
+    it_behaves_like "runnable act callbacks format filter", kind, "Array of String", acceptance: false do
+      let(:format_filter) { %w[html json] }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid formats, got: \"html\", \"json\"" }
+    end
+    it_behaves_like "runnable act callbacks format filter", kind, "Array of String/Symbol", acceptance: false do
+      let(:format_filter) { [:html, "json"] }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid formats, got: \"json\"" }
     end
   end
 end

--- a/spec/support/shared_examples/shared_examples_for_callbacks.rb
+++ b/spec/support/shared_examples/shared_examples_for_callbacks.rb
@@ -26,11 +26,11 @@ RSpec.shared_examples "runnable act callbacks format filter" do |kind, filter, a
   let(:run) { klazz.public_send(kind_act, kind_callback, format: format_filter) }
 
   if acceptance
-    it "accepts #{filter || "action"} filter" do
+    it "accepts #{filter || "format"} filter" do
       expect { run }.not_to raise_error
     end
   else
-    it "rejects #{filter || "action"} filter" do
+    it "rejects #{filter || "format"} filter" do
       expect { run }.to raise_error(error_class_raised, error_message_raised)
     end
   end


### PR DESCRIPTION
support collection argument for  action/format filters in act_callacbks configuration

```rb
class Controller
  include MimeActor::Callbacks

  before_act :load_data, action: [:create, :show], format: :json
  after_act :render_json, format: [:json, :json_api]
  after_act :render_html, format: :json
end
```