### PR TITLE
spec: add act callbacks test sequence

### DIFF
--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -124,6 +124,63 @@ module MimeActor
       end
     end
 
+    # Callbacks invocation sequence depends on the order of callback definition.
+    # (except for callbacks with `format` filter).
+    #
+    # @example callbacks with/without action filter
+    #   before_act :my_before_act_one
+    #   before_act :my_before_act_two, action: :create
+    #   before_act :my_before_act_three
+    #
+    #   around_act :my_around_act_one
+    #   around_act :my_around_act_two, action: :create
+    #   around_act :my_around_act_three
+    #
+    #   after_act :my_after_act_one
+    #   after_act :my_after_act_two, action: :create
+    #   after_act :my_after_act_three
+    #
+    #   # actual sequence:
+    #   # - my_before_act_one
+    #   # - my_before_act_two
+    #   # - my_before_act_three
+    #   # - my_around_act_one
+    #   # - my_around_act_two
+    #   # - my_around_act_three
+    #   # - my_after_act_three
+    #   # - my_after_act_two
+    #   # - my_after_act_one
+    #
+    # @example callbacks with format filter
+    #   before_act :my_before_act_one
+    #   before_act :my_before_act_two, action: :create
+    #   before_act :my_before_act_three, action: :create, format: :html
+    #   before_act :my_before_act_four
+    #
+    #   around_act :my_around_act_one
+    #   around_act :my_around_act_two, action: :create, format: :html
+    #   around_act :my_around_act_three, action: :create
+    #   around_act :my_around_act_four
+    #
+    #   after_act :my_after_act_one, format: :html
+    #   after_act :my_after_act_two
+    #   after_act :my_after_act_three, action: :create
+    #   after_act :my_after_act_four
+    #
+    #   # actual sequence:
+    #   # - my_before_act_one
+    #   # - my_before_act_two
+    #   # - my_before_act_four
+    #   # - my_around_act_one
+    #   # - my_around_act_three
+    #   # - my_around_act_four
+    #   # - my_before_act_three
+    #   # - my_around_act_two
+    #   # - my_after_act_one
+    #   # - my_after_act_four
+    #   # - my_after_act_three
+    #   # - my_after_act_two
+    #
     def run_act_callbacks(format)
       action_chain = self.class.callback_chain_name
       format_chain = self.class.callback_chain_name(format)

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -66,4 +66,125 @@ RSpec.describe MimeActor::Callbacks do
       let(:error_message_raised) { "invalid formats, got: \"json\"" }
     end
   end
+
+  describe "act callbacks sequence" do
+    let(:klazz) { Class.new.include described_class }
+    let(:klazz_instance) { klazz.new }
+    let(:before_callbacks) do
+      klazz.before_act :before_a, action: %i[create show]
+      klazz.before_act :before_f, format: %i[json html]
+      klazz.before_act :before_anything
+    end
+    let(:after_callbacks) do
+      klazz.after_act :after_a, action: :create
+      klazz.after_act :after_f, format: :html
+      klazz.after_act :after_a_f, action: :show, format: :json
+      klazz.after_act :after_anything
+    end
+    let(:around_callbacks) do
+      klazz.around_act :around_a, action: :show
+      klazz.around_act :around_f, format: :json
+      klazz.around_act :around_anything
+    end
+    let(:sequence) { [] }
+
+    before do
+      before_callbacks
+      after_callbacks
+      around_callbacks
+
+      klazz.define_method(:action_name) {}
+      klazz.define_method(:method_missing) { |_method_name, *_args| }
+      klazz.define_method(:respond_to_missing?) { |*_args| true }
+
+      allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
+      allow(klazz_instance).to receive(:method_missing).and_wrap_original do |_method, method_name, *_args, &block|
+        sequence << method_name
+        block.call if block
+      end
+    end
+
+    context "with action name :create" do
+      let(:act_action) { :create }
+
+      it "calls xml callbacks in order" do
+        klazz_instance.run_act_callbacks(:xml)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_anything
+          after_anything
+          after_a
+        ]
+      end
+
+      it "calls html callbacks in order" do
+        klazz_instance.run_act_callbacks(:html)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_anything
+          before_f
+          after_f
+          after_anything
+          after_a
+        ]
+      end
+
+      it "calls json callbacks in order" do
+        klazz_instance.run_act_callbacks(:json)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_anything
+          before_f
+          around_f
+          after_anything
+          after_a
+        ]
+      end
+    end
+
+    context "with action name :show" do
+      let(:act_action) { :show }
+
+      it "calls xml callbacks in order" do
+        klazz_instance.run_act_callbacks(:xml)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_a
+          around_anything
+          after_anything
+        ]
+      end
+
+      it "calls html callbacks in order" do
+        klazz_instance.run_act_callbacks(:html)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_a
+          around_anything
+          before_f
+          after_f
+          after_anything
+        ]
+      end
+
+      it "calls json callbacks in order" do
+        klazz_instance.run_act_callbacks(:json)
+        expect(sequence).to eq %i[
+          before_a
+          before_anything
+          around_a
+          around_anything
+          before_f
+          around_f
+          after_a_f
+          after_anything
+        ]
+      end
+    end
+  end
 end

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -70,120 +70,197 @@ RSpec.describe MimeActor::Callbacks do
   describe "act callbacks sequence" do
     let(:klazz) { Class.new.include described_class }
     let(:klazz_instance) { klazz.new }
-    let(:before_callbacks) do
-      klazz.before_act :before_a, action: %i[create show]
-      klazz.before_act :before_f, format: %i[json html]
-      klazz.before_act :before_anything
-    end
-    let(:after_callbacks) do
-      klazz.after_act :after_a, action: :create
-      klazz.after_act :after_f, format: :html
-      klazz.after_act :after_a_f, action: :show, format: :json
-      klazz.after_act :after_anything
-    end
-    let(:around_callbacks) do
-      klazz.around_act :around_a, action: :show
-      klazz.around_act :around_f, format: :json
-      klazz.around_act :around_anything
-    end
     let(:sequence) { [] }
 
     before do
       before_callbacks
-      after_callbacks
       around_callbacks
+      after_callbacks
 
-      klazz.define_method(:action_name) {}
-      klazz.define_method(:method_missing) { |_method_name, *_args| }
+      klazz.define_method(:action_name) { true }
+      klazz.define_method(:method_missing) { |*_args| true }
       klazz.define_method(:respond_to_missing?) { |*_args| true }
 
       allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
       allow(klazz_instance).to receive(:method_missing).and_wrap_original do |_method, method_name, *_args, &block|
         sequence << method_name
-        block.call if block
+        block&.call
       end
     end
 
-    context "with action name :create" do
+    context "with or without action filter" do
       let(:act_action) { :create }
-
-      it "calls xml callbacks in order" do
-        klazz_instance.run_act_callbacks(:xml)
-        expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_anything
-          after_anything
-          after_a
-        ]
+      let(:before_callbacks) do
+        klazz.before_act :my_before_act_one
+        klazz.before_act :my_before_act_two, action: :create
+        klazz.before_act :my_before_act_three
+      end
+      let(:around_callbacks) do
+        klazz.around_act :my_around_act_one
+        klazz.around_act :my_around_act_two, action: :create
+        klazz.around_act :my_around_act_three
+      end
+      let(:after_callbacks) do
+        klazz.after_act :my_after_act_one
+        klazz.after_act :my_after_act_two, action: :create
+        klazz.after_act :my_after_act_three
       end
 
-      it "calls html callbacks in order" do
+      it "calls in order" do
         klazz_instance.run_act_callbacks(:html)
         expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_anything
-          before_f
-          after_f
-          after_anything
-          after_a
-        ]
-      end
-
-      it "calls json callbacks in order" do
-        klazz_instance.run_act_callbacks(:json)
-        expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_anything
-          before_f
-          around_f
-          after_anything
-          after_a
+          my_before_act_one
+          my_before_act_two
+          my_before_act_three
+          my_around_act_one
+          my_around_act_two
+          my_around_act_three
+          my_after_act_three
+          my_after_act_two
+          my_after_act_one
         ]
       end
     end
 
-    context "with action name :show" do
-      let(:act_action) { :show }
-
-      it "calls xml callbacks in order" do
-        klazz_instance.run_act_callbacks(:xml)
-        expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_a
-          around_anything
-          after_anything
-        ]
+    context "with format filter" do
+      let(:act_action) { :create }
+      let(:before_callbacks) do
+        klazz.before_act :my_before_act_one
+        klazz.before_act :my_before_act_two, action: :create
+        klazz.before_act :my_before_act_three, action: :create, format: :html
+        klazz.before_act :my_before_act_four
+      end
+      let(:around_callbacks) do
+        klazz.around_act :my_around_act_one
+        klazz.around_act :my_around_act_two, action: :create, format: :html
+        klazz.around_act :my_around_act_three, action: :create
+        klazz.around_act :my_around_act_four
+      end
+      let(:after_callbacks) do
+        klazz.after_act :my_after_act_one, format: :html
+        klazz.after_act :my_after_act_two
+        klazz.after_act :my_after_act_three, action: :create
+        klazz.after_act :my_after_act_four
       end
 
-      it "calls html callbacks in order" do
+      it "calls in order" do
         klazz_instance.run_act_callbacks(:html)
         expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_a
-          around_anything
-          before_f
-          after_f
-          after_anything
+          my_before_act_one
+          my_before_act_two
+          my_before_act_four
+          my_around_act_one
+          my_around_act_three
+          my_around_act_four
+          my_before_act_three
+          my_around_act_two
+          my_after_act_one
+          my_after_act_four
+          my_after_act_three
+          my_after_act_two
         ]
       end
+    end
 
-      it "calls json callbacks in order" do
-        klazz_instance.run_act_callbacks(:json)
-        expect(sequence).to eq %i[
-          before_a
-          before_anything
-          around_a
-          around_anything
-          before_f
-          around_f
-          after_a_f
-          after_anything
-        ]
+    context "with different action/format filters" do
+      let(:before_callbacks) do
+        klazz.before_act :before_a, action: %i[create show]
+        klazz.before_act :before_f, format: %i[json html]
+        klazz.before_act :before_anything
+      end
+      let(:around_callbacks) do
+        klazz.around_act :around_a, action: :show
+        klazz.around_act :around_f, format: :json
+        klazz.around_act :around_anything
+      end
+      let(:after_callbacks) do
+        klazz.after_act :after_a, action: :create
+        klazz.after_act :after_f, format: :html
+        klazz.after_act :after_a_f, action: :show, format: :json
+        klazz.after_act :after_anything
+      end
+
+      context "with action name :create" do
+        let(:act_action) { :create }
+
+        it "calls xml callbacks in order" do
+          klazz_instance.run_act_callbacks(:xml)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_anything
+            after_anything
+            after_a
+          ]
+        end
+
+        it "calls html callbacks in order" do
+          klazz_instance.run_act_callbacks(:html)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_anything
+            before_f
+            after_f
+            after_anything
+            after_a
+          ]
+        end
+
+        it "calls json callbacks in order" do
+          klazz_instance.run_act_callbacks(:json)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_anything
+            before_f
+            around_f
+            after_anything
+            after_a
+          ]
+        end
+      end
+
+      context "with action name :show" do
+        let(:act_action) { :show }
+
+        it "calls xml callbacks in order" do
+          klazz_instance.run_act_callbacks(:xml)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_a
+            around_anything
+            after_anything
+          ]
+        end
+
+        it "calls html callbacks in order" do
+          klazz_instance.run_act_callbacks(:html)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_a
+            around_anything
+            before_f
+            after_f
+            after_anything
+          ]
+        end
+
+        it "calls json callbacks in order" do
+          klazz_instance.run_act_callbacks(:json)
+          expect(sequence).to eq %i[
+            before_a
+            before_anything
+            around_a
+            around_anything
+            before_f
+            around_f
+            after_a_f
+            after_anything
+          ]
+        end
       end
     end
   end


### PR DESCRIPTION
callbacks without `format` filter will invoked first.

callback configured as follow
```rb
before_act :my_callback_nothing
before_act :my_callback_format, format: :html
before_act :my_callback_action, action: :create
```

callback sequence as follow
- `:my_callback_nothing`
- `:my_callback_action`
- `:my_callback_format`
