### PR TITLE
feat: run act callbacks during `start_scene`

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -2,6 +2,7 @@
 
 # :markup: markdown
 
+require "mime_actor/callbacks"
 require "mime_actor/logging"
 require "mime_actor/scene"
 require "mime_actor/stage"
@@ -25,6 +26,7 @@ module MimeActor
     include AbstractController::Rendering # required by MimeResponds
     include ActionController::MimeResponds
 
+    include Callbacks
     include Scene
     include Stage
     include Logging
@@ -54,7 +56,11 @@ module MimeActor
 
       respond_to do |collector|
         formats.each do |format, actor|
-          dispatch = -> { cue_actor(actor.presence || "#{action}_#{format}", action:, format:) }
+          dispatch = lambda do
+            run_act_callbacks(format) do
+              cue_actor(actor.presence || "#{action}_#{format}", action:, format:)
+            end
+          end
           collector.public_send(format, &dispatch)
         end
       end

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -62,6 +62,40 @@ RSpec.describe MimeActor::Action do
       end
     end
 
+    context "with act callbacks" do
+      before do
+        klazz.define_method(:action_name) { "create" }
+        klazz.define_method(actor_name) { "my actor" }
+
+        klazz.before_act :my_before_callback, action: :create
+        klazz.before_act :my_html_callback, format: :html
+        klazz.after_act :my_after_html_callback, action: :create, format: :html
+
+        klazz.define_method(:my_before_callback) { "my callback" }
+        klazz.define_method(:my_html_callback) { "my html" }
+        klazz.define_method(:my_after_html_callback) { "my after html" }
+
+        allow(klazz_instance).to receive(actor_name).and_call_original
+        allow(klazz_instance).to receive(:my_before_callback)
+        allow(klazz_instance).to receive(:my_html_callback)
+        allow(klazz_instance).to receive(:my_after_html_callback)
+      end
+
+      it "run callbacks" do
+        allow(klazz_instance).to receive(:respond_to).and_yield(stub_collector)
+
+        allow(stub_collector).to receive(:html) do |&block|
+          expect(block.call).to eq "my actor"
+          expect(klazz_instance).to have_received(:my_before_callback).ordered
+          expect(klazz_instance).to have_received(:my_html_callback).ordered
+          expect(klazz_instance).to have_received(actor_name).ordered
+          expect(klazz_instance).to have_received(:my_after_html_callback).ordered
+        end
+
+        expect { start }.not_to raise_error
+      end
+    end
+
     describe "when actor is defined" do
       before { klazz.define_method(actor_name) { "my actor" } }
 


### PR DESCRIPTION
run act callbacks in `#start_scene` before calling the `actor`.

