### PR TITLE
lib: allow actor of any visibility to be called

### DIFF
--- a/lib/mime_actor/dispatcher.rb
+++ b/lib/mime_actor/dispatcher.rb
@@ -16,7 +16,7 @@ module MimeActor
       end
 
       def call(target)
-        raise MimeActor::ActorNotFound, method_name unless target.respond_to?(method_name)
+        raise MimeActor::ActorNotFound, method_name unless target.respond_to?(method_name, true)
 
         method_call = target.method(method_name)
         filtered_args = method_call.arity.negative? ? args : args.take(method_call.arity)

--- a/spec/mime_actor/dispatcher_spec.rb
+++ b/spec/mime_actor/dispatcher_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe MimeActor::Dispatcher do
           expect(dispatch.call("my_string")).to eq :my_string
         end
       end
+
+      context "with method visibility" do
+        let(:stub_target_class) { stub_const "StubTarget", Class.new }
+        let(:stub_target) { stub_target_class.new }
+
+        before do
+          stub_target_class.define_method(:my_public_method) { "public" }
+          stub_target_class.define_method(:my_protected_method) { "protected" }
+          stub_target_class.instance_eval { protected :my_protected_method }
+          stub_target_class.define_method(:my_private_method) { "private" }
+          stub_target_class.instance_eval { private :my_private_method }
+        end
+
+        %i[public protected private].each do |visibility|
+          context "with target's #{visibility} method" do
+            let(:dispatch) { dispatcher.new(:"my_#{visibility}_method") }
+
+            it "calls" do
+              expect(dispatch.call(stub_target)).to eq visibility.to_s
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Allow `actor` of any visibility to be called.

In action controller context, any public method would be registered as `action_method` which then can be bind in route config. For some cases, users might not want to have internal helper method to be exposed yet they want to use it as `actor` method.

This affects `#cue_actor` & `#rescue_actor`