### PR TITLE
feat: rescue act callbacks

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -2,7 +2,6 @@
 
 # :markup: markdown
 
-require "mime_actor/callbacks"
 require "mime_actor/logging"
 require "mime_actor/scene"
 require "mime_actor/stage"
@@ -26,7 +25,6 @@ module MimeActor
     include AbstractController::Rendering # required by MimeResponds
     include ActionController::MimeResponds
 
-    include Callbacks
     include Scene
     include Stage
     include Logging
@@ -56,11 +54,7 @@ module MimeActor
 
       respond_to do |collector|
         formats.each do |format, actor|
-          dispatch = lambda do
-            run_act_callbacks(format) do
-              cue_actor(actor.presence || "#{action}_#{format}", action:, format:)
-            end
-          end
+          dispatch = -> { cue_actor(actor.presence || "#{action}_#{format}", action:, format:) }
           collector.public_send(format, &dispatch)
         end
       end

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -62,40 +62,6 @@ RSpec.describe MimeActor::Action do
       end
     end
 
-    context "with act callbacks" do
-      before do
-        klazz.define_method(:action_name) { "create" }
-        klazz.define_method(actor_name) { "my actor" }
-
-        klazz.before_act :my_before_callback, action: :create
-        klazz.before_act :my_html_callback, format: :html
-        klazz.after_act :my_after_html_callback, action: :create, format: :html
-
-        klazz.define_method(:my_before_callback) { "my callback" }
-        klazz.define_method(:my_html_callback) { "my html" }
-        klazz.define_method(:my_after_html_callback) { "my after html" }
-
-        allow(klazz_instance).to receive(actor_name).and_call_original
-        allow(klazz_instance).to receive(:my_before_callback)
-        allow(klazz_instance).to receive(:my_html_callback)
-        allow(klazz_instance).to receive(:my_after_html_callback)
-      end
-
-      it "run callbacks" do
-        allow(klazz_instance).to receive(:respond_to).and_yield(stub_collector)
-
-        allow(stub_collector).to receive(:html) do |&block|
-          expect(block.call).to eq "my actor"
-          expect(klazz_instance).to have_received(:my_before_callback).ordered
-          expect(klazz_instance).to have_received(:my_html_callback).ordered
-          expect(klazz_instance).to have_received(actor_name).ordered
-          expect(klazz_instance).to have_received(:my_after_html_callback).ordered
-        end
-
-        expect { start }.not_to raise_error
-      end
-    end
-
     describe "when actor is defined" do
       before { klazz.define_method(actor_name) { "my actor" } }
 

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -2,8 +2,6 @@
 
 require "mime_actor/stage"
 
-require "active_support/logger"
-
 RSpec.describe MimeActor::Stage do
   let(:klazz) { Class.new.include described_class }
 

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -216,21 +216,22 @@ RSpec.describe MimeActor::Stage do
     describe "#rescue_actor" do
       include_context "with stage cue"
 
-      let(:actor) { -> { raise "my error" } }
+      let(:actor) { -> { raise "my actor error" } }
+      let(:actor_error) { RuntimeError.new("my error") }
       let(:action_filter) { :abc }
-      let(:format_filter) { "xyz" }
+      let(:format_filter) { :json }
 
       before { klazz.define_method(:rescue_actor) { |*_args| "rescue" } }
 
       describe "when error is handled" do
         it "does not bubbles up" do
-          allow(klazz_instance).to receive(:rescue_actor).and_return(true)
-          expect { cue }.not_to raise_error
+          allow(klazz_instance).to receive(:rescue_actor).and_return(actor_error)
+          expect(cue).to eq actor_error
           expect(klazz_instance).to have_received(:rescue_actor).with(
             kind_of(RuntimeError),
             a_hash_including(
               action: :abc,
-              format: "xyz"
+              format: :json
             )
           )
         end
@@ -241,10 +242,85 @@ RSpec.describe MimeActor::Stage do
           allow(klazz_instance).to receive(:rescue_actor).and_return(nil)
           expect { cue }.to raise_error do |ex|
             expect(ex).to be_a(RuntimeError)
-            expect(ex.message).to eq "my error"
+            expect(ex.message).to eq "my actor error"
           end
           expect(klazz_instance).to have_received(:rescue_actor)
         end
+      end
+
+      describe "when error raised in callbacks" do
+        let(:actor) { :my_actor }
+        let(:callback_error) { RuntimeError.new("my error callback") }
+
+        before do
+          klazz.define_method(:action_name) { "abc" }
+          klazz.define_method(actor) { "my actor" }
+          allow(klazz_instance).to receive(actor).and_call_original
+
+          klazz.before_act :my_before_callback, action: action_filter
+          klazz.after_act :my_after_callback, format: format_filter
+          klazz.define_method(:my_before_callback) { "before error" }
+          klazz.define_method(:my_after_callback) { "after error" }
+        end
+
+        it "rescues before callback" do
+          allow(klazz_instance).to receive(:my_before_callback).and_raise(callback_error)
+          allow(klazz_instance).to receive(:my_after_callback)
+          allow(klazz_instance).to receive(:rescue_actor).and_return(callback_error)
+
+          expect(cue).to eq callback_error
+
+          expect(klazz_instance).to have_received(:my_before_callback).ordered
+          expect(klazz_instance).not_to have_received(actor).ordered
+          expect(klazz_instance).not_to have_received(:my_after_callback).ordered
+        end
+
+        it "rescues after callback" do
+          allow(klazz_instance).to receive(:my_before_callback)
+          allow(klazz_instance).to receive(:my_after_callback).and_raise(callback_error)
+          allow(klazz_instance).to receive(:rescue_actor).and_return(callback_error)
+
+          expect(cue).to eq callback_error
+
+          expect(klazz_instance).to have_received(:my_before_callback).ordered
+          expect(klazz_instance).to have_received(actor).ordered
+          expect(klazz_instance).to have_received(:my_after_callback).ordered
+        end
+      end
+    end
+
+    context "with act callbacks" do
+      include_context "with stage cue"
+
+      let(:action_filter) { :create }
+      let(:format_filter) { :html }
+      let(:actor) { :my_actor }
+
+      before do
+        klazz.define_method(:action_name) { "create" }
+        klazz.define_method(actor) { "my actor" }
+
+        klazz.before_act :my_before_callback, action: :create
+        klazz.before_act :my_html_callback, format: :html
+        klazz.after_act :my_after_html_callback, action: :create, format: :html
+
+        klazz.define_method(:my_before_callback) { "my callback" }
+        klazz.define_method(:my_html_callback) { "my html" }
+        klazz.define_method(:my_after_html_callback) { "my after html" }
+
+        allow(klazz_instance).to receive(actor).and_call_original
+        allow(klazz_instance).to receive(:my_before_callback)
+        allow(klazz_instance).to receive(:my_html_callback)
+        allow(klazz_instance).to receive(:my_after_html_callback)
+      end
+
+      it "run callbacks" do
+        expect(cue).to eq "my actor"
+
+        expect(klazz_instance).to have_received(:my_before_callback).ordered
+        expect(klazz_instance).to have_received(:my_html_callback).ordered
+        expect(klazz_instance).to have_received(actor).ordered
+        expect(klazz_instance).to have_received(:my_after_html_callback).ordered
       end
     end
   end

--- a/spec/support/shared_context/shared_context_for_stage.rb
+++ b/spec/support/shared_context/shared_context_for_stage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/logger"
+
 RSpec.shared_context "with stage cue" do
   let(:klazz) { Class.new.include described_class }
   let(:klazz_instance) { klazz.new }

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
       let(:acting_instructions) { "overheard the news" }
 
       before do
-        klazz.define_method(actor_method) do |scripts|
+        klazz.define_method(actor) do |scripts|
           "shed tears of joy when #{scripts}"
         end
       end
@@ -22,7 +22,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
 
     context "without instructions" do
       before do
-        klazz.define_method(actor_method) { "a meaningless truth" }
+        klazz.define_method(actor) { "a meaningless truth" }
       end
 
       it "returns result from actor" do
@@ -32,12 +32,12 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
 
     context "with block passed" do
       let(:cue) do
-        klazz_instance.cue_actor(actor_method, *acting_instructions, action: nil, format: nil, &another_block)
+        klazz_instance.cue_actor(actor, *acting_instructions, action: nil, format: nil, &another_block)
       end
       let(:another_block) { ->(num) { num**num } }
 
       before do
-        klazz.define_method(actor_method) { 3 }
+        klazz.define_method(actor) { 3 }
       end
 
       it "yield the block wih the result from actor" do
@@ -56,7 +56,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
     it "logs a error message" do
       expect(cue).to be_nil
       expect(stub_logger).to have_received(:error) do |&logger|
-        expect(logger.call).to eq "actor error, cause: <MimeActor::ActorNotFound> #{actor_method.inspect} not found"
+        expect(logger.call).to eq "actor error, cause: <MimeActor::ActorNotFound> #{actor.inspect} not found"
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
       before { klazz.raise_on_actor_error = true }
 
       it "raises #{MimeActor::ActorNotFound}" do
-        expect { cue }.to raise_error(MimeActor::ActorNotFound, "#{actor_method.inspect} not found")
+        expect { cue }.to raise_error(MimeActor::ActorNotFound, "#{actor.inspect} not found")
       end
     end
   end


### PR DESCRIPTION
move `run_act_callbacks` from `MimeActor::Action` to `MimeActor::Stage` to allow rescuers to handle error raised in callbacks as well as dispatcher.