### PR TITLE
fix: use controller#action_name

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -31,10 +31,9 @@ module MimeActor
 
     # The core logic where rendering logics are collected as `Proc` and passed over to `ActionController::MimeResponds`
     #
-    # @param action the `action` of the controller
-    #
     # @example process `create` action
-    #   start_scene(:create)
+    #   # it uses AbstractController#action_name to process
+    #   start_scene
     #
     #   # it is equivalent to the following if `create` action is configured with `html` and `json` formats
     #   def create
@@ -44,17 +43,18 @@ module MimeActor
     #     end
     #   end
     #
-    def start_scene(action)
+    def start_scene
+      action = action_name.to_sym
       formats = acting_scenes.fetch(action, {})
 
       if formats.empty?
-        logger.warn { "format is empty for action: #{action.inspect}" }
+        logger.warn { "format is empty for action: #{action_name.inspect}" }
         return
       end
 
       respond_to do |collector|
         formats.each do |format, actor|
-          dispatch = -> { cue_actor(actor.presence || "#{action}_#{format}", action:, format:) }
+          dispatch = -> { cue_actor(actor.presence || "#{action}_#{format}", format:) }
           collector.public_send(format, &dispatch)
         end
       end

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -116,11 +116,11 @@ module MimeActor
       def define_scene(action)
         module_eval(
           # def index
-          #   self.respond_to?(:start_scene) && self.start_scene(:index)
+          #   self.respond_to?(:start_scene) && self.start_scene
           # end
           <<-RUBY, __FILE__, __LINE__ + 1
             def #{action}
-              self.respond_to?(:start_scene) && self.start_scene(:#{action})
+              self.respond_to?(:start_scene) && self.start_scene
             end
           RUBY
         )

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -78,7 +78,7 @@ module MimeActor
     # @param actor either a method name or a Proc to evaluate
     # @param args arguments to be passed when calling the actor
     #
-    def cue_actor(actor, *args, action:, format:)
+    def cue_actor(actor, *args, format:)
       dispatcher = MimeActor::Dispatcher.build(actor, *args)
       raise TypeError, "invalid actor, got: #{actor.inspect}" unless dispatcher
 
@@ -90,7 +90,7 @@ module MimeActor
       logger.error { "actor error, cause: #{e.inspect}" } unless raise_on_actor_error
       raise e if raise_on_actor_error
     rescue StandardError => e
-      rescued = rescue_actor(e, action:, format:)
+      rescued = rescue_actor(e, action: action_name.to_sym, format: format)
       rescued || raise
     end
   end

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -23,15 +23,18 @@ RSpec.describe MimeActor::Action do
   end
 
   describe "#start_scene" do
-    let(:start) { klazz_instance.start_scene(:create) }
     let(:klazz_instance) { klazz.new }
+    let(:start) { klazz_instance.start_scene }
+    let(:start_action) { :create }
     let(:actor_name) { "create_html" }
     let(:stub_collector) { instance_double(ActionController::MimeResponds::Collector) }
     let(:stub_logger) { instance_double(ActiveSupport::Logger) }
 
     before do
-      klazz.respond_act_to :html, on: :create
+      klazz.respond_act_to :html, on: start_action
       klazz.config.logger = stub_logger
+      klazz.define_method(:action_name) { "placeholder" }
+      allow(klazz_instance).to receive(:action_name).and_return(start_action.to_s)
     end
 
     context "with acting_scenes" do
@@ -57,7 +60,7 @@ RSpec.describe MimeActor::Action do
       it "logs missing formats" do
         expect { start }.not_to raise_error
         expect(stub_logger).to have_received(:warn) do |&logger|
-          expect(logger.call).to eq "format is empty for action: :create"
+          expect(logger.call).to eq "format is empty for action: \"create\""
         end
       end
     end
@@ -75,7 +78,7 @@ RSpec.describe MimeActor::Action do
         expect(stub_collector).to have_received(:html) do |&block|
           allow(klazz_instance).to receive(:cue_actor).and_call_original
           expect(block.call).to eq "my actor"
-          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, action: :create, format: :html)
+          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, format: :html)
         end
       end
     end
@@ -91,7 +94,7 @@ RSpec.describe MimeActor::Action do
         expect(stub_collector).to have_received(:html) do |&block|
           allow(klazz_instance).to receive(:cue_actor)
           block.call
-          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, action: :create, format: :html)
+          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, format: :html)
         end
       end
     end

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe MimeActor::Callbacks do
       around_callbacks
       after_callbacks
 
-      klazz.define_method(:action_name) { true }
-      klazz.define_method(:method_missing) { |*_args| true }
-      klazz.define_method(:respond_to_missing?) { |*_args| true }
+      klazz.define_method(:action_name) { "placeholder" }
+      klazz.define_method(:method_missing) { |*_args| "missed" }
+      klazz.define_method(:respond_to_missing?) { |*_args| "responded" }
 
       allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
       allow(klazz_instance).to receive(:method_missing).and_wrap_original do |_method, method_name, *_args, &block|

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe MimeActor::Stage do
 
       context "with block passed" do
         let(:cue) do
-          klazz_instance.cue_actor(actor, *acting_instructions, action: nil, format: nil, &another_actor)
+          klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter, &another_actor)
         end
         let(:actor) { -> { 4 } }
         let(:another_actor) { ->(num) { num**num } }
@@ -250,10 +250,10 @@ RSpec.describe MimeActor::Stage do
 
       describe "when error raised in callbacks" do
         let(:actor) { :my_actor }
+        let(:action_filter) { :abc }
         let(:callback_error) { RuntimeError.new("my error callback") }
 
         before do
-          klazz.define_method(:action_name) { "abc" }
           klazz.define_method(actor) { "my actor" }
           allow(klazz_instance).to receive(actor).and_call_original
 
@@ -297,7 +297,6 @@ RSpec.describe MimeActor::Stage do
       let(:actor) { :my_actor }
 
       before do
-        klazz.define_method(:action_name) { "create" }
         klazz.define_method(actor) { "my actor" }
 
         klazz.before_act :my_before_callback, action: :create

--- a/spec/support/shared_context/shared_context_for_callbacks.rb
+++ b/spec/support/shared_context/shared_context_for_callbacks.rb
@@ -8,7 +8,7 @@ RSpec.shared_context "with act callbacks" do
   let(:run) { klazz_instance.run_act_callbacks(act_format) }
 
   before do
-    klazz.define_method(:action_name) { "something" }
+    klazz.define_method(:action_name) { "placholder" }
     allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
   end
 end

--- a/spec/support/shared_context/shared_context_for_stage.rb
+++ b/spec/support/shared_context/shared_context_for_stage.rb
@@ -6,12 +6,16 @@ RSpec.shared_context "with stage cue" do
   let(:klazz) { Class.new.include described_class }
   let(:klazz_instance) { klazz.new }
   let(:acting_instructions) { [] }
-  let(:action_filter) { nil }
-  let(:format_filter) { nil }
+  let(:action_filter) { :create }
+  let(:format_filter) { :html }
   let(:stub_logger) { instance_double(ActiveSupport::Logger) }
   let(:cue) do
-    klazz_instance.cue_actor(actor, *acting_instructions, action: action_filter, format: format_filter)
+    klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter)
   end
 
-  before { klazz.config.logger = stub_logger }
+  before do
+    klazz.define_method(:action_name) { "placeholder" }
+    allow(klazz_instance).to receive(:action_name).and_return(action_filter.to_s)
+    klazz.config.logger = stub_logger
+  end
 end

--- a/spec/support/shared_examples/shared_examples_for_rescue.rb
+++ b/spec/support/shared_examples/shared_examples_for_rescue.rb
@@ -42,12 +42,12 @@ RSpec.shared_examples "rescuable action filter" do |action_name, acceptance: tru
   include_context "with rescuable filter", :action
 
   if acceptance
-    it "accepts #{action_name || "the format"}" do
+    it "accepts #{action_name || "the action"}" do
       expect { rescuable }.not_to raise_error
       expect(klazz.actor_rescuers).to include(["StandardError", nil, action_params, kind_of(Symbol)])
     end
   else
-    it "accepts #{action_name || "the format"}" do
+    it "accepts #{action_name || "the action"}" do
       expect { rescuable }.to raise_error(error_class_raised, error_message_raised)
       expect(klazz.actor_rescuers).to be_empty
     end

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -121,15 +121,15 @@ RSpec.shared_examples "composable scene action method" do |scene_name|
   describe "when #start_scene is defined for #{scene_name || "the scene"}" do
     let(:klazz_instance) { klazz.new }
 
-    before { klazz.define_method(:start_scene) { |action_name| "start a scene with #{action_name}" } }
+    before { klazz.define_method(:start_scene) { "start a scene" } }
 
     it "called by the newly defined action method" do
       expect { compose }.not_to raise_error
       allow(klazz_instance).to receive(:start_scene).and_call_original
       expected_scenes.each_key do |action_name|
-        expect(klazz_instance.send(action_name)).to eq "start a scene with #{action_name}"
-        expect(klazz_instance).to have_received(:start_scene).with(action_name)
+        expect(klazz_instance.send(action_name)).to eq "start a scene"
       end
+      expect(klazz_instance).to have_received(:start_scene).exactly(expected_scenes.size)
     end
   end
 

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -32,7 +32,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
 
     context "with block passed" do
       let(:cue) do
-        klazz_instance.cue_actor(actor, *acting_instructions, action: nil, format: nil, &another_block)
+        klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter, &another_block)
       end
       let(:another_block) { ->(num) { num**num } }
 


### PR DESCRIPTION
avoid passing `action` around when running through the flow from `#start_scene` to `#cue_actor`.

instead read directly from `Controller#action_name` to be aligned with `MimeActor::Callbacks`

https://github.com/ryancyq/mime_actor/blob/d2c41718c749764852dd589d265a6ae313f6eba1/lib/mime_actor/callbacks.rb#L41-L43