### PR TITLE
refactor: rename with validator into callable validator

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -49,7 +49,7 @@ module MimeActor
         raise ArgumentError, "error filter is required" if klazzes.empty?
         raise ArgumentError, "provide either the with: argument or a block" unless with.present? ^ block_given?
 
-        validate!(:with, with) if with.present?
+        validate!(:callable, with) if with.present?
         with = block if block_given?
 
         validate!(:action_or_actions, action) if action.present?

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -86,7 +86,7 @@ module MimeActor
 
         raise ArgumentError, "provide either the with: argument or a block" if with.present? && block_given?
 
-        validate!(:with, with) if with.present?
+        validate!(:callable, with) if with.present?
         with = block if block_given?
 
         raise ArgumentError, "action is required" unless (actions = on).present?

--- a/lib/mime_actor/validator.rb
+++ b/lib/mime_actor/validator.rb
@@ -96,13 +96,13 @@ module MimeActor
         TypeError.new("#{unchecked.inspect} must be a Class/Module or a String referencing a Class/Module")
       end
 
-      # Validate `with` must be a Symbol or Proc
+      # Validate `callable` must be a Symbol or Proc
       #
-      # @param unchecked the `with` to be validated
-      def validate_with(unchecked)
+      # @param unchecked the `callable` to be validated
+      def validate_callable(unchecked)
         return if unchecked.is_a?(Proc) || unchecked.is_a?(Symbol)
 
-        TypeError.new("with handler must be a Symbol or Proc, got: #{unchecked.inspect}")
+        TypeError.new("#{unchecked.inspect} must be a Symbol or Proc")
       end
     end
   end

--- a/spec/mime_actor/rescue_spec.rb
+++ b/spec/mime_actor/rescue_spec.rb
@@ -151,12 +151,12 @@ RSpec.describe MimeActor::Rescue do
       it_behaves_like "rescuable with handler", "String", String, acceptance: false do
         let(:handler) { "custom_handler" }
         let(:error_class_raised) { TypeError }
-        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
+        let(:error_message_raised) { "\"custom_handler\" must be a Symbol or Proc" }
       end
       it_behaves_like "rescuable with handler", "Method", Method, acceptance: false do
         let(:handler) { method(:to_s) }
         let(:error_class_raised) { TypeError }
-        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
+        let(:error_message_raised) { %r{Method.*#to_s.* must be a Symbol or Proc} }
       end
     end
 

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -122,12 +122,12 @@ RSpec.describe MimeActor::Scene do
       it_behaves_like "composable scene with handler", "String", String, acceptance: false do
         let(:handler) { "custom_handler" }
         let(:error_class_raised) { TypeError }
-        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
+        let(:error_message_raised) { "\"custom_handler\" must be a Symbol or Proc" }
       end
       it_behaves_like "composable scene with handler", "Method", Method, acceptance: false do
         let(:handler) { method(:to_s) }
         let(:error_class_raised) { TypeError }
-        let(:error_message_raised) { "with handler must be a Symbol or Proc, got: #{handler.inspect}" }
+        let(:error_message_raised) { %r{Method.*#to_s.* must be a Symbol or Proc} }
       end
     end
 


### PR DESCRIPTION
rename `with` validator into `callable` validator for more generic naming