### PR TITLE
feat: actor delegator

### DIFF
--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -47,7 +47,7 @@ module MimeActor
       #
       def rescue_act_from(*klazzes, action: nil, format: nil, with: nil, &block)
         raise ArgumentError, "error filter is required" if klazzes.empty?
-        raise ArgumentError, "provide either the with: argument or a block" unless with.present? ^ block_given?
+        raise ArgumentError, "provide either with: or a block" unless with.present? ^ block_given?
 
         validate!(:callable, with) if with.present?
         with = block if block_given?

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -84,7 +84,7 @@ module MimeActor
       def respond_act_to(*formats, on: nil, with: nil, &block)
         validate!(:formats, formats)
 
-        raise ArgumentError, "provide either the with: argument or a block" if with.present? && block_given?
+        raise ArgumentError, "provide either with: or a block" if with.present? && block_given?
 
         validate!(:callable, with) if with.present?
         with = block if block_given?

--- a/spec/mime_actor/rescue_spec.rb
+++ b/spec/mime_actor/rescue_spec.rb
@@ -129,9 +129,9 @@ RSpec.describe MimeActor::Rescue do
       end
 
       describe "when block is given" do
-        let(:handler) { proc {} }
+        let(:empty_block) { proc {} }
         let(:rescue_act) do
-          klazz.rescue_act_from StandardError, with: proc {}, &handler
+          klazz.rescue_act_from StandardError, with: proc {}, &empty_block
         end
 
         it "must be absent" do
@@ -161,9 +161,9 @@ RSpec.describe MimeActor::Rescue do
     end
 
     describe "#block" do
-      let(:handler) { proc {} }
+      let(:empty_block) { proc {} }
       let(:rescue_act) do
-        klazz.rescue_act_from StandardError, &handler
+        klazz.rescue_act_from StandardError, &empty_block
       end
 
       it "be the handler" do

--- a/spec/mime_actor/rescue_spec.rb
+++ b/spec/mime_actor/rescue_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe MimeActor::Rescue do
         let(:rescue_act) { klazz.rescue_act_from StandardError }
 
         it "required" do
-          expect { rescue_act }.to raise_error(ArgumentError, "provide either the with: argument or a block")
+          expect { rescue_act }.to raise_error(ArgumentError, "provide either with: or a block")
         end
       end
 
@@ -135,7 +135,7 @@ RSpec.describe MimeActor::Rescue do
         end
 
         it "must be absent" do
-          expect { rescue_act }.to raise_error(ArgumentError, "provide either the with: argument or a block")
+          expect { rescue_act }.to raise_error(ArgumentError, "provide either with: or a block")
         end
       end
 

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe MimeActor::Scene do
         let(:compose) { klazz.respond_act_to :html, on: :create, with: proc {}, &empty_block }
 
         it "must be absent" do
-          expect { compose }.to raise_error(ArgumentError, "provide either the with: argument or a block")
+          expect { compose }.to raise_error(ArgumentError, "provide either with: or a block")
         end
       end
 


### PR DESCRIPTION
Resolve #5 

Differ from what was mentioned in #28. Having actor delegator customizable for each scene composition will cause multiple generators being configured and does not have much benefits from maintaining such customization.

In this PR, we define a class level generator that would be used by all scene composition with minimum complexity being introduced.