### PR TITLE
fix: backport active support logger 6.X

### DIFF
--- a/lib/mime_actor/logging.rb
+++ b/lib/mime_actor/logging.rb
@@ -2,6 +2,10 @@
 
 # :markup: markdown
 
+# required by active_support/tagged_logging
+require "active_support/version"
+require "active_support/isolated_execution_state" if ActiveSupport::VERSION::MAJOR >= 7
+
 require "active_support/concern"
 require "active_support/configurable"
 require "active_support/logger"
@@ -17,7 +21,14 @@ module MimeActor
     include ActiveSupport::Configurable
 
     included do
-      config_accessor :logger, default: ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
+       default_logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
+      if ActiveSupport::VERSION::MAJOR >= 7
+        config_accessor :logger, default: default_logger
+      else
+        config_accessor :logger do
+          default_logger
+        end
+      end
     end
 
     private


### PR DESCRIPTION
 - isolated_executed_state https://github.com/rails/rails/commit/0ea374c81f6b3af1e8adac6d6337a4ae54e8d73b
 - config_accessor with default value https://github.com/rails/rails/commit/99525cb6ffee2dadf4b11ce1a8094a353ef1a566