### PR TITLE
feat: #act_on_action to replace #respond_act_to

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -28,10 +28,6 @@ module MimeActor
     include Stage
     include Logging
 
-    included do
-      mattr_accessor :actor_delegator, instance_writer: false, default: ->(action, format) { "#{action}_#{format}" }
-    end
-
     # The core logic where rendering logics are collected as `Proc` and passed over to `ActionController::MimeResponds`
     #
     # @example process `create` action

--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -51,16 +51,18 @@ module MimeActor
     def start_scene
       action = action_name.to_sym
       formats = acting_scenes.fetch(action, {})
+      return respond_to_scene(action, formats) unless formats.empty?
 
-      if formats.empty?
-        logger.warn { "format is empty for action: #{action_name.inspect}" }
-        return
-      end
+      logger.warn { "no format found for action: #{action_name.inspect}" }
+    end
 
+    private
+
+    def respond_to_scene(action, formats)
       respond_to do |collector|
         formats.each do |format, actor|
           callable = actor.presence || actor_delegator.call(action, format)
-          dispatch = -> { cue_actor(callable, format:) }
+          dispatch = -> { cue_actor(callable, action, format, format:) }
           collector.public_send(format, &dispatch)
         end
       end

--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -30,15 +30,17 @@ module MimeActor
 
     # The core logic where rendering logics are collected as `Proc` and passed over to `ActionController::MimeResponds`
     #
+    # @param block the block to be evaluated
+    #
     # @example process `create` action
     #   # it uses AbstractController#action_name to process
-    #   start_scene
+    #   start_scene { create_internal }
     #
     #   # it is equivalent to the following if `create` action is configured with `html` and `json` formats
     #   def create
     #     respond_to |format|
-    #       format.html { public_send(:create_html) }
-    #       format.json { public_send(:create_json) }
+    #       format.html { create_internal }
+    #       format.json { create_internal }
     #     end
     #   end
     #

--- a/lib/mime_actor/errors.rb
+++ b/lib/mime_actor/errors.rb
@@ -39,12 +39,6 @@ module MimeActor
     end
   end
 
-  class ActionExisted < ActionError
-    def generate_message
-      "action #{action.inspect} already existed"
-    end
-  end
-
   class ActionNotImplemented < ActionError
     def generate_message
       "action #{action.inspect} not implemented"

--- a/lib/mime_actor/errors.rb
+++ b/lib/mime_actor/errors.rb
@@ -44,4 +44,10 @@ module MimeActor
       "action #{action.inspect} already existed"
     end
   end
+
+  class ActionNotImplemented < ActionError
+    def generate_message
+      "action #{action.inspect} not implemented"
+    end
+  end
 end

--- a/lib/mime_actor/rescue.rb
+++ b/lib/mime_actor/rescue.rb
@@ -6,9 +6,7 @@ require "mime_actor/dispatcher"
 require "mime_actor/validator"
 
 require "active_support/concern"
-require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/module/attribute_accessors"
-require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/inflections"
 
 module MimeActor
@@ -93,8 +91,8 @@ module MimeActor
       return unless error
 
       *_, rescuer = actor_rescuers.reverse_each.detect do |rescuee, format_filter, action_filter|
-        next unless action_filter.nil? || Array.wrap(action_filter).include?(action)
-        next unless format_filter.nil? || Array.wrap(format_filter).include?(format)
+        next unless action_filter.nil? || Array(action_filter).include?(action)
+        next unless format_filter.nil? || Array(format_filter).include?(format)
         next unless (klazz = constantize_rescuee(rescuee))
 
         error.is_a?(klazz)

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -162,7 +162,12 @@ module MimeActor
             owner.define_cached_method(action, namespace: :mime_scene) do |batch|
               batch.push(
                 "def #{action}",
-                "respond_to?(:start_scene) ? start_scene { super } : super",
+                "if respond_to?(:start_scene)",
+                "start_scene { raise #{MimeActor::ActionNotImplemented}, :#{action} unless defined?(super); super } ",
+                "else",
+                "raise #{MimeActor::ActionNotImplemented}, :#{action} unless defined?(super)",
+                "super",
+                "end",
                 "end"
               )
             end

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -5,10 +5,9 @@
 require "mime_actor/errors"
 require "mime_actor/validator"
 
+require "active_support/code_generator"
 require "active_support/concern"
-require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/module/attribute_accessors"
-require "active_support/core_ext/object/blank"
 
 module MimeActor
   # # MimeActor Scene
@@ -98,7 +97,78 @@ module MimeActor
         end
       end
 
+      # Register `action` + `format` definitions.
+      #
+      # @param action a collection of `action`
+      # @param format a single `format` or a collection of `format`
+      # @param with the response handler for the given `action` + `format`
+      # @param block the `block` to be yieled for the given `action` + `format`
+      #
+      # @example register a `html` format on action `create`
+      #   act_on_action :create, format: :html
+      #
+      #   # an action method will be defined in the class
+      #   def indexl; end
+      # @example register `html`, `json` formats on actions `index`, `show`
+      #   act_on_action :index, :show, format: [:html, :json]
+      #
+      #   # these action methods will be defined in the class
+      #   def index; end
+      #   def show; end
+      # @example register a `html` format on action `index` with response handler method
+      #   act_on_action :index, format: :html, with: :render_html
+      #
+      #   # an action method will be defined in the class
+      #   def index; end
+      #   # the given method should be defined in the class
+      #   def render_html; end
+      # @example register a `html` format on action `index` with response handler block
+      #   act_on_action :html, on: :index do
+      #     render :index
+      #   end
+      #
+      #   # an action method will be defined in the class
+      #   def index; end
+      #
+      # For each unique `action` being registered, a corresponding `action` method will be defined.
+      def act_on_action(*actions, format:, with: nil, &block)
+        raise ArgumentError, "format is required" if format.nil?
+        raise ArgumentError, "provide either with: or a block" if !with.nil? && block_given?
+
+        validate!(:actions, actions)
+        validate!(:format_or_formats, format)
+        validate!(:callable, with) unless with.nil?
+        with = block if block_given?
+
+        actions.each do |action|
+          acting_scenes[action] ||= {}
+          Array(format).each do |action_format|
+            acting_scenes[action][action_format] = with
+          end
+        end
+
+        generate_action_methods(actions)
+      end
+
       private
+
+      def generated_action_methods
+        @generated_action_methods ||= Module.new.tap { |mod| prepend mod }
+      end
+
+      def generate_action_methods(actions)
+        ActiveSupport::CodeGenerator.batch(generated_action_methods, __FILE__, __LINE__) do |owner|
+          actions.each do |action|
+            owner.define_cached_method(action, namespace: :mime_scene) do |batch|
+              batch.push(
+                "def #{action}",
+                "respond_to?(:start_scene) ? start_scene { super } : super",
+                "end"
+              )
+            end
+          end
+        end
+      end
 
       def compose_scene(action, format, actor)
         action_defined = (instance_methods + private_instance_methods).include?(action.to_sym)

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -14,26 +14,20 @@ module MimeActor
   #
   # Scene provides configuration for `action` + `format` definitions
   #
-  # @example register a `html` format on action `index`
-  #   respond_act_to :html, on: :index
+  # @example register a `html` format on action `create`
+  #   act_on_action :create, format: :html
   #
-  #   # this method should be defined in the class
-  #   def index_html; end
   # @example register `html`, `json` formats on actions `index`, `show`
-  #   respond_act_to :html, :json , on: [:index, :show]
+  #   act_on_action :index, :show, format: [:html, :json]
   #
-  #   # these methods should be defined in the class
-  #   def index_html; end
-  #   def index_json; end
-  #   def show_html; end
-  #   def show_json; end
   # @example register a `html` format on action `index` with respond handler method
-  #   respond_act_to :html, on: :index, with: :render_html
+  #   act_on_action :index, format: :html, with: :render_html
   #
-  #   # this method should be defined in the class
-  #   def render_html; end
-  # @example register a `html` format on action `index` with respond handler proc
-  #   respond_act_to :html, on: :index do
+  # @example register a `html` format on action `index` with respond handler Proc
+  #   act_on_action :index, format: :html, with: -> { render html: "<h1>my header</h1>" }
+  #
+  # @example register a `html` format on action `index` with respond handler block
+  #   act_on_action :html, on: :index do
   #     render :index
   #   end
   #
@@ -53,7 +47,7 @@ module MimeActor
       #
       # @param action a collection of `action`
       # @param format a single `format` or a collection of `format`
-      # @param with the response handler for the given `action` + `format`
+      # @param with the respond handler for the given `action` + `format`
       # @param block the `block` to be yieled for the given `action` + `format`
       #
       # @example register a `html` format on action `create`
@@ -67,14 +61,21 @@ module MimeActor
       #   # these action methods will be defined in the class
       #   def index; end
       #   def show; end
-      # @example register a `html` format on action `index` with response handler method
+      # @example register a `html` format on action `index` with respond handler method
       #   act_on_action :index, format: :html, with: :render_html
       #
       #   # an action method will be defined in the class
+      #   # the handler method will be called by the action method.
       #   def index; end
       #   # the given method should be defined in the class
       #   def render_html; end
-      # @example register a `html` format on action `index` with response handler block
+      # @example register a `html` format on action `index` with respond handler Proc
+      #   act_on_action :index, format: :html, with: -> { render html: "<h1>my header</h1>" }
+      #
+      #   # an action method will be defined in the class,
+      #   # the handler Proc will be called by the action method.
+      #   def index; end
+      # @example register a `html` format on action `index` with respond handler block
       #   act_on_action :html, on: :index do
       #     render :index
       #   end

--- a/lib/mime_actor/scene.rb
+++ b/lib/mime_actor/scene.rb
@@ -51,54 +51,6 @@ module MimeActor
     module ClassMethods
       # Register `action` + `format` definitions.
       #
-      # @param formats the collection of `format`
-      # @param on the collection of `action`
-      # @param with the respond handler when `block` is not provided
-      # @param block the `block` to evaluate when `with` is not provided
-      #
-      # @example register a `html` format on action `index`
-      #   respond_act_to :html, on: :index
-      #
-      #   # this method should be defined in the class
-      #   def index_html; end
-      # @example register `html`, `json` formats on actions `index`, `show`
-      #   respond_act_to :html, :json , on: [:index, :show]
-      #
-      #   # these methods should be defined in the class
-      #   def index_html; end
-      #   def index_json; end
-      #   def show_html; end
-      #   def show_json; end
-      # @example register a `html` format on action `index` with respond handler method
-      #   respond_act_to :html, on: :index, with: :render_html
-      #
-      #   # this method should be defined in the class
-      #   def render_html; end
-      # @example register a `html` format on action `index` with respond handler proc
-      #   respond_act_to :html, on: :index do
-      #     render :index
-      #   end
-      #
-      # For each unique `action` being registered, it will have a corresponding `action` method being defined.
-      def respond_act_to(*formats, on: nil, with: nil, &block)
-        validate!(:formats, formats)
-
-        raise ArgumentError, "provide either with: or a block" if !with.nil? && block_given?
-
-        validate!(:callable, with) unless with.nil?
-        with = block if block_given?
-
-        raise ArgumentError, "action is required" if (actions = on).nil?
-
-        validate!(:action_or_actions, actions)
-
-        Array.wrap(actions).each do |action|
-          formats.each { |format| compose_scene(action, format, with) }
-        end
-      end
-
-      # Register `action` + `format` definitions.
-      #
       # @param action a collection of `action`
       # @param format a single `format` or a collection of `format`
       # @param with the response handler for the given `action` + `format`
@@ -173,29 +125,6 @@ module MimeActor
             end
           end
         end
-      end
-
-      def compose_scene(action, format, actor)
-        action_defined = (instance_methods + private_instance_methods).include?(action.to_sym)
-        raise MimeActor::ActionExisted, action if !acting_scenes.key?(action) && action_defined
-
-        acting_scenes[action] ||= {}
-        acting_scenes[action][format] = actor
-
-        define_scene(action) unless action_defined
-      end
-
-      def define_scene(action)
-        module_eval(
-          # def index
-          #   self.respond_to?(:start_scene) && self.start_scene
-          # end
-          <<-RUBY, __FILE__, __LINE__ + 1
-            def #{action}
-              self.respond_to?(:start_scene) && self.start_scene
-            end
-          RUBY
-        )
       end
     end
   end

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -28,16 +28,16 @@ RSpec.describe ActionController::Metal do
   describe "when actor method is defined" do
     before do
       controller_class.respond_act_to :json, on: :new
-      controller_class.define_method(action_actor) { render plain: :ok }
+      controller_class.define_method(action_actor) { equal?("my actor 123") }
     end
 
     it "calls the actor method" do
       expect(controller_class.action_methods).to include(action_actor)
       expect(controller_class).to be_method_defined(action_actor)
 
-      allow(controller).to receive(action_actor).and_call_original
+      allow(controller).to receive(:equal?)
       expect { dispatch }.not_to raise_error
-      expect(controller).to have_received(action_actor)
+      expect(controller).to have_received(:equal?).with("my actor 123")
     end
   end
 

--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor method is defined" do
     before do
-      controller_class.respond_act_to :json, on: :new
+      controller_class.act_on_action :new, format: :json
       controller_class.define_method(action_actor) { equal?("my actor 123") }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ActionController::Metal do
 
   describe "when actor methods for some formats are undefined" do
     before do
-      controller_class.respond_act_to :json, :html, on: :new
+      controller_class.act_on_action :new, format: %i[json html]
       controller_class.define_method(:new_html) { render plain: :ok }
     end
 

--- a/spec/examples/events_controller.rb
+++ b/spec/examples/events_controller.rb
@@ -13,34 +13,33 @@ class EventsController < ActionController::Base
 
   act_on_action :update, format: %i[html json]
   act_on_action :index, :show, format: :html, with: :render_html
-  act_on_action :index, :show, format: :json, with: -> { render json: { action: action_name } }
+  act_on_action :index, :show, :update, format: :json, with: -> { render json: { action: action_name } }
+
+  after_act -> { redirect_to "/events/#{@event.id}" }, action: :update, format: :html
 
   rescue_act_from ActiveRecord::RecordNotFound, format: :json, with: :handle_json_error
+  rescue_act_from ActiveRecord::RecordNotFound, format: :html, action: :show, with: :handle_update_error_html
   rescue_act_from ActiveRecord::RecordNotFound, format: :html, action: :show, with: -> { redirect_to "/events" }
+
+  def update
+    # ...
+  end
 
   private
 
-  def update_html
-    # ...
-    redirect_to "/events/#{@event.id}" # redirect to show upon sucessful update
-  rescue ActiveRecord::RecordNotFound
-    render html: :edit
-  end
-
-  def update_json
-    # ...
-    render json: @event # render with #to_json
+  def load_event
+    @event = Event.find(params.require(:event_id))
   end
 
   def render_html
     render html: action_name
   end
 
-  def load_event
-    @event = Event.find(params.require(:event_id))
-  end
-
   def handle_json_error(error)
     render status: :bad_request, json: { error: error.message }
+  end
+
+  def handle_update_error_html
+    render html: :edit
   end
 end

--- a/spec/examples/events_controller.rb
+++ b/spec/examples/events_controller.rb
@@ -11,9 +11,9 @@ class EventsController < ActionController::Base
   before_act :load_event, action: %i[show update]
   before_act -> { @event_categories = EventCategory.all }, action: :show, format: :html
 
-  respond_act_to :html, :json, on: :update
-  respond_act_to :html, on: %i[index show], with: :render_html
-  respond_act_to :json, on: %i[index show], with: -> { render json: { action: action_name } }
+  act_on_action :update, format: %i[html json]
+  act_on_action :index, :show, format: :html, with: :render_html
+  act_on_action :index, :show, format: :json, with: -> { render json: { action: action_name } }
 
   rescue_act_from ActiveRecord::RecordNotFound, format: :json, with: :handle_json_error
   rescue_act_from ActiveRecord::RecordNotFound, format: :html, action: :show, with: -> { redirect_to "/events" }

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe MimeActor::Action do
       it "logs missing formats" do
         expect { start }.not_to raise_error
         expect(stub_logger).to have_received(:warn) do |&logger|
-          expect(logger.call).to eq "format is empty for action: \"create\""
+          expect(logger.call).to eq "no format found for action: \"create\""
         end
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe MimeActor::Action do
         expect(stub_collector).to have_received(:html) do |&block|
           allow(klazz_instance).to receive(:cue_actor).and_call_original
           expect(block.call).to eq "my actor"
-          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, format: :html)
+          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, :create, :html, format: :html)
         end
       end
     end
@@ -169,7 +169,7 @@ RSpec.describe MimeActor::Action do
         expect(stub_collector).to have_received(:html) do |&block|
           allow(klazz_instance).to receive(:cue_actor)
           expect(block.call).to be_nil
-          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, format: :html)
+          expect(klazz_instance).to have_received(:cue_actor).with(actor_name, :create, :html, format: :html)
         end
       end
     end

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -22,26 +22,6 @@ RSpec.describe MimeActor::Action do
     end
   end
 
-  describe "#actor_delegator" do
-    it "allows class attribute reader" do
-      expect(klazz.actor_delegator).to be_a(Proc)
-    end
-
-    it "allows class attribute writter" do
-      expect { klazz.actor_delegator = true }.not_to raise_error
-    end
-
-    it "allows instance reader" do
-      expect(klazz.new.actor_delegator).to be_a(Proc)
-    end
-
-    it "disallows instance writter" do
-      expect { klazz.new.actor_delegator = true }.to raise_error(
-        NoMethodError, %r{undefined method `actor_delegator='}
-      )
-    end
-  end
-
   describe "#start_scene" do
     let(:klazz_instance) { klazz.new }
     let(:start) { klazz_instance.start_scene }
@@ -62,61 +42,6 @@ RSpec.describe MimeActor::Action do
         allow(klazz_instance).to receive(:respond_to)
         expect { start }.not_to raise_error
         expect(klazz_instance).to have_received(:respond_to)
-      end
-
-      describe "#actor_delegator" do
-        before do
-          allow(klazz_instance).to receive(:respond_to).and_yield(stub_collector)
-          allow(klazz_instance).to receive(:actor_delegator).and_call_original
-          allow(stub_collector).to receive(:html)
-        end
-
-        context "when with/block is not provided" do
-          let(:stub_delegator) { instance_double(Proc, call: "to_s") }
-
-          before do
-            klazz.respond_act_to :json, on: start_action
-            allow(stub_collector).to receive(:json)
-          end
-
-          it "calls to get actor name" do
-            expect { start }.not_to raise_error
-            expect(klazz_instance).to have_received(:actor_delegator).twice
-          end
-
-          it "calls with action & format" do
-            allow(klazz_instance).to receive(:actor_delegator).and_return(stub_delegator)
-            expect { start }.not_to raise_error
-            expect(stub_delegator).to have_received(:call).with(start_action, :html)
-            expect(stub_delegator).to have_received(:call).with(start_action, :json)
-          end
-        end
-
-        context "when with is provided" do
-          before do
-            klazz.respond_act_to :json, on: start_action, with: :all_rounder
-            allow(stub_collector).to receive(:json)
-          end
-
-          it "does not call" do
-            expect { start }.not_to raise_error
-            expect(klazz_instance).not_to have_received(:actor_delegator).with(start_action, :json)
-          end
-        end
-
-        context "when block is provided" do
-          let(:empty_block) { proc {} }
-
-          before do
-            klazz.respond_act_to :json, on: start_action, &empty_block
-            allow(stub_collector).to receive(:json)
-          end
-
-          it "does not call" do
-            expect { start }.not_to raise_error
-            expect(klazz_instance).not_to have_received(:actor_delegator).with(start_action, :json)
-          end
-        end
       end
     end
 

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MimeActor::Action do
     let(:stub_logger) { instance_double(ActiveSupport::Logger) }
 
     before do
-      klazz.respond_act_to :html, on: start_action
+      klazz.act_on_action start_action, format: :html
       klazz.config.logger = stub_logger
       klazz.define_method(:action_name) { "placeholder" }
       allow(klazz_instance).to receive(:action_name).and_return(start_action.to_s)

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe MimeActor::Scene do
   describe "#act_on_action" do
     it_behaves_like "composable scene action", "Nil", acceptance: false do
       let(:action_filter) { nil }
-      let(:error_class_raised) { ArgumentError }
-      let(:error_message_raised) { "action is required" }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid actions, got: nil" }
     end
     it_behaves_like "composable scene action", "Empty Array", acceptance: false do
       let(:action_filter) { [] }
@@ -24,8 +24,8 @@ RSpec.describe MimeActor::Scene do
     end
     it_behaves_like "composable scene action", "String", acceptance: false do
       let(:action_filter) { "create" }
-      let(:error_class_raised) { TypeError }
-      let(:error_message_raised) { "action must be a Symbol" }
+      let(:error_class_raised) { NameError }
+      let(:error_message_raised) { "invalid actions, got: \"create\"" }
     end
     it_behaves_like "composable scene action", "Array of String", acceptance: false do
       let(:action_filter) { %w[index create] }
@@ -43,8 +43,8 @@ RSpec.describe MimeActor::Scene do
 
     it_behaves_like "composable scene format", "Nil", acceptance: false do
       let(:format_filter) { nil }
-      let(:error_class_raised) { NameError }
-      let(:error_message_raised) { "invalid formats, got: nil" }
+      let(:error_class_raised) { ArgumentError }
+      let(:error_message_raised) { "format is required" }
     end
     it_behaves_like "composable scene format", "Empty Array", acceptance: false do
       let(:format_filter) { [] }

--- a/spec/mime_actor/scene_spec.rb
+++ b/spec/mime_actor/scene_spec.rb
@@ -5,7 +5,7 @@ require "mime_actor/scene"
 RSpec.describe MimeActor::Scene do
   let(:klazz) { Class.new.include described_class }
 
-  describe "#respond_act_to" do
+  describe "#act_on_action" do
     it_behaves_like "composable scene action", "Nil", acceptance: false do
       let(:action_filter) { nil }
       let(:error_class_raised) { ArgumentError }
@@ -65,7 +65,7 @@ RSpec.describe MimeActor::Scene do
       it_behaves_like "composable scene format", "Symbol", acceptance: false do
         let(:format_filter) { :my_custom }
         let(:error_class_raised) { NameError }
-        let(:error_message_raised) { "invalid formats, got: :my_custom" }
+        let(:error_message_raised) { "invalid format, got: :my_custom" }
       end
       it_behaves_like "composable scene format", "Array of Symbol", acceptance: false do
         let(:format_filter) { %i[html my_custom xml] }
@@ -95,7 +95,7 @@ RSpec.describe MimeActor::Scene do
 
     describe "#with" do
       describe "when block is not given" do
-        let(:compose) { klazz.respond_act_to :html, on: :create }
+        let(:compose) { klazz.act_on_action :create, format: :html }
 
         it "optional" do
           expect { compose }.not_to raise_error
@@ -104,7 +104,7 @@ RSpec.describe MimeActor::Scene do
 
       describe "when block is given" do
         let(:empty_block) { proc {} }
-        let(:compose) { klazz.respond_act_to :html, on: :create, with: proc {}, &empty_block }
+        let(:compose) { klazz.act_on_action :create, format: :html, with: proc {}, &empty_block }
 
         it "must be absent" do
           expect { compose }.to raise_error(ArgumentError, "provide either with: or a block")
@@ -134,7 +134,7 @@ RSpec.describe MimeActor::Scene do
 
     describe "#block" do
       let(:empty_block) { proc {} }
-      let(:compose) { klazz.respond_act_to :html, on: :show, &empty_block }
+      let(:compose) { klazz.act_on_action :show, format: :html, &empty_block }
 
       it "be the handler" do
         expect(klazz.acting_scenes).to be_empty
@@ -147,18 +147,18 @@ RSpec.describe MimeActor::Scene do
     describe "when is called multiple times" do
       it "merges the scenes" do
         expect(klazz.acting_scenes).to be_empty
-        klazz.respond_act_to(:html, on: %i[index create])
+        klazz.act_on_action(:index, :create, format: :html)
         expect(klazz.acting_scenes).to include(
           index:  { html: anything },
           create: { html: anything }
         )
-        klazz.respond_act_to(:xml, on: %i[create update])
+        klazz.act_on_action(:create, :update, format: :xml)
         expect(klazz.acting_scenes).to include(
           index:  { html: anything },
           create: { html: anything, xml: anything },
           update: { xml: anything }
         )
-        klazz.respond_act_to(:json, :xml, on: %i[create show])
+        klazz.act_on_action(:create, :show, format: %i[json xml])
         expect(klazz.acting_scenes).to include(
           index:  { html: anything },
           create: { html: anything, xml: anything, json: anything },

--- a/spec/support/shared_context/shared_context_for_scene.rb
+++ b/spec/support/shared_context/shared_context_for_scene.rb
@@ -5,10 +5,10 @@ RSpec.shared_context "with scene composition" do
   let(:action_filter) { :create }
   let(:format_filter) { :html }
   let(:compose) do
-    if format_filter.is_a?(Enumerable)
-      klazz.respond_act_to(*format_filter, on: action_filter)
+    if action_filter.is_a?(Enumerable)
+      klazz.act_on_action(*action_filter, format: format_filter)
     else
-      klazz.respond_act_to(format_filter, on: action_filter)
+      klazz.act_on_action(action_filter, format: format_filter)
     end
   end
 end

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -138,16 +138,4 @@ RSpec.shared_examples "composable scene action method" do |scene_name|
       expect(klazz_instance).to have_received(:start_scene).exactly(expected_scenes.size)
     end
   end
-
-  describe "when #start_scene is undefined for #{scene_name || "the scene"}" do
-    let(:klazz_instance) { klazz.new }
-
-    it "does not get called by the newly defined action method" do
-      expect(klazz).not_to be_method_defined(:start_scene)
-      expect { compose }.not_to raise_error
-      expected_scenes.each_key do |action_name|
-        expect(klazz_instance.send(action_name)).to be_falsey
-      end
-    end
-  end
 end

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples "composable scene action" do |action_name, acceptance: tru
     it "rejects #{action_name || "the action"}" do
       expect(klazz.acting_scenes).to be_empty
       expect { compose }.to raise_error(error_class_raised, error_message_raised)
-      expect(klazz.acting_scenes.keys).not_to include([])
+      expect(klazz.acting_scenes).to be_empty
     end
   end
 end
@@ -43,9 +43,9 @@ RSpec.shared_examples "composable scene with handler" do |handler_name, handler_
 
   let(:compose) do
     if format_filter.is_a?(Enumerable)
-      klazz.respond_act_to(*format_filter, on: action_filter, with: handler)
+      klazz.act_on_action(*action_filter, format: format_filter, with: handler)
     else
-      klazz.respond_act_to(format_filter, on: action_filter, with: handler)
+      klazz.act_on_action(action_filter, format: format_filter, with: handler)
     end
   end
   let(:expected_scenes) do

--- a/spec/support/shared_examples/shared_examples_for_scene.rb
+++ b/spec/support/shared_examples/shared_examples_for_scene.rb
@@ -110,20 +110,6 @@ RSpec.shared_examples "composable scene action method" do |scene_name|
     end
   end
 
-  describe "when action method has already defined for #{scene_name || "the scene"}" do
-    before do
-      expected_scenes.each_key do |action_name|
-        klazz.define_method(action_name) { "stub #{action_name}" }
-      end
-    end
-
-    it "raises #{MimeActor::ActionExisted}" do
-      expect { compose }.to raise_error(
-        MimeActor::ActionExisted, "action :#{expected_scenes.keys.first} already existed"
-      )
-    end
-  end
-
   describe "when #start_scene is defined for #{scene_name || "the scene"}" do
     let(:klazz_instance) { klazz.new }
 


### PR DESCRIPTION
The main difference between `#act_on_action` and `#respond_act_to`

`#respond_act_to`
- define the action method (e.g. `create`, `index`) in the controller (prohibits declaration of the same method in the controller by the user)
- wrap respond handler (e.g. `<action>_<format>` method) with callbacks and rescue handlers.
- respond handler can be specified through (any of the followings) 
  - `#actor_delegator`
  - `with:` argument when calling `#respond_act_to`

`#act_on_action`
- define the action method by prepending the action method in the controller, wrap super method with callbacks and rescue handlers.
 - enforces user to configure respond handler through (any of the followings)  
   - implement the action method (e.g. `create`, `index`) in the controller
   - implement the provided method name in `with:` argument when calling `#respond_act_to`
   - provide a Proc through `with:` argument when calling `#respond_act_to`