### PR TITLE
refactor: callback generator

### DIFF
--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -30,7 +30,6 @@ module MimeActor
     included do
       define_callbacks :act, skip_after_callbacks_if_terminated: true
 
-      %i[before after around].each { |kind| define_act_callbacks(kind) }
       generate_act_callback_methods
     end
 
@@ -127,39 +126,6 @@ module MimeActor
             "end"
           )
         end
-      end
-
-      def define_act_callbacks(kind)
-        module_eval(
-          # def self.before_act(*callbacks, action: nil, format: nil, &block)
-          #   validate_callback_options!(action, format)
-          #   configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
-          #     set_callback(chain, :before, callback, options)
-          #   end
-          # end
-          #
-          # def self.prepend_before_act(*callbacks, action: nil, format: nil, &block)
-          #   validate_callback_options!(action, format)
-          #   configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
-          #     set_callback(chain, :before, callback, options.merge!(prepend: true))
-          #   end
-          # end
-          <<-RUBY, __FILE__, __LINE__ + 1
-            def self.#{kind}_act(*callbacks, action: nil, format: nil, &block)
-              validate_callback_options!(action, format)
-              configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
-                set_callback(chain, :#{kind}, callback, options)
-              end
-            end
-
-            def self.prepend_#{kind}_act(*callbacks, action: nil, format: nil, &block)
-              validate_callback_options!(action, format)
-              configure_callbacks(callbacks, action, format, block) do |chain, callback, options|
-                set_callback(chain, :#{kind}, callback, options.merge!(prepend: true))
-              end
-            end
-          RUBY
-        )
       end
     end
 

--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -15,9 +15,15 @@ module MimeActor
   #
   # MimeActor provides hooks during the life cycle of an act. Available callbacks are:
   #
-  # - before_act
-  # - around_act
-  # - after_act
+  # - append_act_before
+  # - append_act_around
+  # - append_act_after
+  # - act_before
+  # - act_around
+  # - act_after
+  # - prepend_act_before
+  # - prepend_act_around
+  # - prepend_act_after
   #
   # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
   #
@@ -133,58 +139,58 @@ module MimeActor
     # (except for callbacks with `format` filter).
     #
     # @example callbacks with/without action filter
-    #   before_act :my_before_act_one
-    #   before_act :my_before_act_two, action: :create
-    #   before_act :my_before_act_three
+    #   act_before :my_act_before_one
+    #   act_before :my_act_before_two, action: :create
+    #   act_before :my_act_before_three
     #
-    #   around_act :my_around_act_one
-    #   around_act :my_around_act_two, action: :create
-    #   around_act :my_around_act_three
+    #   act_around :my_act_around_one
+    #   act_around :my_act_around_two, action: :create
+    #   act_around :my_act_around_three
     #
-    #   after_act :my_after_act_one
-    #   after_act :my_after_act_two, action: :create
-    #   after_act :my_after_act_three
+    #   act_after :my_act_after_one
+    #   act_after :my_act_after_two, action: :create
+    #   act_after :my_act_after_three
     #
     #   # actual sequence:
-    #   # - my_before_act_one
-    #   # - my_before_act_two
-    #   # - my_before_act_three
-    #   # - my_around_act_one
-    #   # - my_around_act_two
-    #   # - my_around_act_three
-    #   # - my_after_act_three
-    #   # - my_after_act_two
-    #   # - my_after_act_one
+    #   # - my_act_before_one
+    #   # - my_act_before_two
+    #   # - my_act_before_three
+    #   # - my_act_around_one
+    #   # - my_act_around_two
+    #   # - my_act_around_three
+    #   # - my_act_after_three
+    #   # - my_act_after_two
+    #   # - my_act_after_one
     #
     # @example callbacks with format filter
-    #   before_act :my_before_act_one
-    #   before_act :my_before_act_two, action: :create
-    #   before_act :my_before_act_three, action: :create, format: :html
-    #   before_act :my_before_act_four
+    #   act_before :my_act_before_one
+    #   act_before :my_act_before_two, action: :create
+    #   act_before :my_act_before_three, action: :create, format: :html
+    #   act_before :my_act_before_four
     #
-    #   around_act :my_around_act_one
-    #   around_act :my_around_act_two, action: :create, format: :html
-    #   around_act :my_around_act_three, action: :create
-    #   around_act :my_around_act_four
+    #   act_around :my_act_around_one
+    #   act_around :my_act_around_two, action: :create, format: :html
+    #   act_around :my_act_around_three, action: :create
+    #   act_around :my_act_around_four
     #
-    #   after_act :my_after_act_one, format: :html
-    #   after_act :my_after_act_two
-    #   after_act :my_after_act_three, action: :create
-    #   after_act :my_after_act_four
+    #   act_after :my_act_after_one, format: :html
+    #   act_after :my_act_after_two
+    #   act_after :my_act_after_three, action: :create
+    #   act_after :my_act_after_four
     #
     #   # actual sequence:
-    #   # - my_before_act_one
-    #   # - my_before_act_two
-    #   # - my_before_act_four
-    #   # - my_around_act_one
-    #   # - my_around_act_three
-    #   # - my_around_act_four
-    #   # - my_before_act_three
-    #   # - my_around_act_two
-    #   # - my_after_act_one
-    #   # - my_after_act_four
-    #   # - my_after_act_three
-    #   # - my_after_act_two
+    #   # - my_act_before_one
+    #   # - my_act_before_two
+    #   # - my_act_before_four
+    #   # - my_act_around_one
+    #   # - my_act_around_three
+    #   # - my_act_around_four
+    #   # - my_act_before_three
+    #   # - my_act_around_two
+    #   # - my_act_after_one
+    #   # - my_act_after_four
+    #   # - my_act_after_three
+    #   # - my_act_after_two
     #
     def run_act_callbacks(format)
       action_chain = self.class.callback_chain_name

--- a/spec/examples/events_controller.rb
+++ b/spec/examples/events_controller.rb
@@ -7,15 +7,15 @@ require "action_controller"
 class EventsController < ActionController::Base
   include MimeActor::Action
 
-  before_act -> { @events = Event.all }, action: :index
-  before_act :load_event, action: %i[show update]
-  before_act -> { @event_categories = EventCategory.all }, action: :show, format: :html
+  act_before -> { @events = Event.all }, action: :index
+  act_before :load_event, action: %i[show update]
+  act_before -> { @event_categories = EventCategory.all }, action: :show, format: :html
 
   act_on_action :update, format: %i[html json]
   act_on_action :index, :show, format: :html, with: :render_html
   act_on_action :index, :show, :update, format: :json, with: -> { render json: { action: action_name } }
 
-  after_act -> { redirect_to "/events/#{@event.id}" }, action: :update, format: :html
+  act_after -> { redirect_to "/events/#{@event.id}" }, action: :update, format: :html
 
   rescue_act_from ActiveRecord::RecordNotFound, format: :json, with: :handle_json_error
   rescue_act_from ActiveRecord::RecordNotFound, format: :html, action: :show, with: :handle_update_error_html

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -101,33 +101,33 @@ RSpec.describe MimeActor::Callbacks do
     context "with or without action filter" do
       let(:act_action) { :create }
       let(:before_callbacks) do
-        klazz.before_act :my_before_act_one
-        klazz.before_act :my_before_act_two, action: :create
-        klazz.before_act :my_before_act_three
+        klazz.act_before :my_act_before_one
+        klazz.act_before :my_act_before_two, action: :create
+        klazz.act_before :my_act_before_three
       end
       let(:around_callbacks) do
-        klazz.around_act :my_around_act_one
-        klazz.around_act :my_around_act_two, action: :create
-        klazz.around_act :my_around_act_three
+        klazz.act_around :my_act_around_one
+        klazz.act_around :my_act_around_two, action: :create
+        klazz.act_around :my_act_around_three
       end
       let(:after_callbacks) do
-        klazz.after_act :my_after_act_one
-        klazz.after_act :my_after_act_two, action: :create
-        klazz.after_act :my_after_act_three
+        klazz.act_after :my_act_after_one
+        klazz.act_after :my_act_after_two, action: :create
+        klazz.act_after :my_act_after_three
       end
 
       it "calls in order" do
         klazz_instance.run_act_callbacks(:html)
         expect(sequence).to eq %i[
-          my_before_act_one
-          my_before_act_two
-          my_before_act_three
-          my_around_act_one
-          my_around_act_two
-          my_around_act_three
-          my_after_act_three
-          my_after_act_two
-          my_after_act_one
+          my_act_before_one
+          my_act_before_two
+          my_act_before_three
+          my_act_around_one
+          my_act_around_two
+          my_act_around_three
+          my_act_after_three
+          my_act_after_two
+          my_act_after_one
         ]
       end
     end
@@ -135,59 +135,59 @@ RSpec.describe MimeActor::Callbacks do
     context "with format filter" do
       let(:act_action) { :create }
       let(:before_callbacks) do
-        klazz.before_act :my_before_act_one
-        klazz.before_act :my_before_act_two, action: :create
-        klazz.before_act :my_before_act_three, action: :create, format: :html
-        klazz.before_act :my_before_act_four
+        klazz.act_before :my_act_before_one
+        klazz.act_before :my_act_before_two, action: :create
+        klazz.act_before :my_act_before_three, action: :create, format: :html
+        klazz.act_before :my_act_before_four
       end
       let(:around_callbacks) do
-        klazz.around_act :my_around_act_one
-        klazz.around_act :my_around_act_two, action: :create, format: :html
-        klazz.around_act :my_around_act_three, action: :create
-        klazz.around_act :my_around_act_four
+        klazz.act_around :my_act_around_one
+        klazz.act_around :my_act_around_two, action: :create, format: :html
+        klazz.act_around :my_act_around_three, action: :create
+        klazz.act_around :my_act_around_four
       end
       let(:after_callbacks) do
-        klazz.after_act :my_after_act_one, format: :html
-        klazz.after_act :my_after_act_two
-        klazz.after_act :my_after_act_three, action: :create
-        klazz.after_act :my_after_act_four
+        klazz.act_after :my_act_after_one, format: :html
+        klazz.act_after :my_act_after_two
+        klazz.act_after :my_act_after_three, action: :create
+        klazz.act_after :my_act_after_four
       end
 
       it "calls in order" do
         klazz_instance.run_act_callbacks(:html)
         expect(sequence).to eq %i[
-          my_before_act_one
-          my_before_act_two
-          my_before_act_four
-          my_around_act_one
-          my_around_act_three
-          my_around_act_four
-          my_before_act_three
-          my_around_act_two
-          my_after_act_one
-          my_after_act_four
-          my_after_act_three
-          my_after_act_two
+          my_act_before_one
+          my_act_before_two
+          my_act_before_four
+          my_act_around_one
+          my_act_around_three
+          my_act_around_four
+          my_act_before_three
+          my_act_around_two
+          my_act_after_one
+          my_act_after_four
+          my_act_after_three
+          my_act_after_two
         ]
       end
     end
 
     context "with different action/format filters" do
       let(:before_callbacks) do
-        klazz.before_act :before_a, action: %i[create show]
-        klazz.before_act :before_f, format: %i[json html]
-        klazz.before_act :before_anything
+        klazz.act_before :before_a, action: %i[create show]
+        klazz.act_before :before_f, format: %i[json html]
+        klazz.act_before :before_anything
       end
       let(:around_callbacks) do
-        klazz.around_act :around_a, action: :show
-        klazz.around_act :around_f, format: :json
-        klazz.around_act :around_anything
+        klazz.act_around :around_a, action: :show
+        klazz.act_around :around_f, format: :json
+        klazz.act_around :around_anything
       end
       let(:after_callbacks) do
-        klazz.after_act :after_a, action: :create
-        klazz.after_act :after_f, format: :html
-        klazz.after_act :after_a_f, action: :show, format: :json
-        klazz.after_act :after_anything
+        klazz.act_after :after_a, action: :create
+        klazz.act_after :after_f, format: :html
+        klazz.act_after :after_a_f, action: :show, format: :json
+        klazz.act_after :after_anything
       end
 
       context "with action name :create" do

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe MimeActor::Stage do
           klazz.define_method(actor) { "my actor" }
           allow(klazz_instance).to receive(actor).and_call_original
 
-          klazz.before_act :my_before_callback, action: action_filter
-          klazz.after_act :my_after_callback, format: format_filter
+          klazz.act_before :my_before_callback, action: action_filter
+          klazz.act_after :my_after_callback, format: format_filter
           klazz.define_method(:my_before_callback) { "before error" }
           klazz.define_method(:my_after_callback) { "after error" }
         end
@@ -187,9 +187,9 @@ RSpec.describe MimeActor::Stage do
       before do
         klazz.define_method(actor) { "my actor" }
 
-        klazz.before_act :my_before_callback, action: :create
-        klazz.before_act :my_html_callback, format: :html
-        klazz.after_act :my_after_html_callback, action: :create, format: :html
+        klazz.act_before :my_before_callback, action: :create
+        klazz.act_before :my_html_callback, format: :html
+        klazz.act_after :my_after_html_callback, action: :create, format: :html
 
         klazz.define_method(:my_before_callback) { "my callback" }
         klazz.define_method(:my_html_callback) { "my html" }

--- a/spec/support/shared_examples/shared_examples_for_callbacks.rb
+++ b/spec/support/shared_examples/shared_examples_for_callbacks.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples "runnable act callbacks action filter" do |kind, filter, acceptance: true|
   let(:klazz) { Class.new.include described_class }
-  let(:kind_act) { :"#{kind}_act" }
+  let(:kind_act) { :"act_#{kind}" }
   let(:kind_callback) { :"my_#{kind}" }
   let(:action_filter) { nil }
   let(:run) { klazz.public_send(kind_act, kind_callback, action: action_filter) }
@@ -20,7 +20,7 @@ end
 
 RSpec.shared_examples "runnable act callbacks format filter" do |kind, filter, acceptance: true|
   let(:klazz) { Class.new.include described_class }
-  let(:kind_act) { :"#{kind}_act" }
+  let(:kind_act) { :"act_#{kind}" }
   let(:kind_callback) { :"my_#{kind}" }
   let(:format_filter) { nil }
   let(:run) { klazz.public_send(kind_act, kind_callback, format: format_filter) }
@@ -40,7 +40,7 @@ RSpec.shared_examples "runnable act callbacks" do |kind|
   include_context "with act callbacks"
 
   describe ":#{kind}" do
-    let(:kind_act) { :"#{kind}_act" }
+    let(:kind_act) { :"act_#{kind}" }
     let(:kind_callback) { :"my_#{kind}" }
 
     before do


### PR DESCRIPTION
- use `#ActiveSupport::CodeGenerator` for batch multiple `#module_eval`
- rename the following
  - `#before_act` to `#act_around`
  - `#after_act` to `#act_around`
  - `#around_act` to `#act_around`
  - `#prepend_before_act` to `#prepend_act_around`
  - `#prepend_after_act` to `#prepend_act_around`
  - `#prepend_around_act` to `#prepend_act_around`
- added the following
  - `#append_act_around`
  - `#append_act_around`
  - `#append_act_around`