### PR TITLE
fix: callback chain sequence respect definition ordering

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -67,7 +67,7 @@ module MimeActor
             next
           end
 
-          dispatch = -> { cue_actor(callable, action, format, format:) }
+          dispatch = -> { cue_actor(callable, action, format, action:, format:) }
           collector.public_send(format, &dispatch)
         end
       end

--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -160,15 +160,15 @@ module MimeActor
     #   # - my_act_before_one
     #   # - my_act_before_two
     #   # - my_act_before_four
+    #   # - my_act_before_three
     #   # - my_act_around_one
+    #   # - my_act_around_two
     #   # - my_act_around_three
     #   # - my_act_around_four
-    #   # - my_act_before_three
-    #   # - my_act_around_two
-    #   # - my_act_after_one
     #   # - my_act_after_four
     #   # - my_act_after_three
     #   # - my_act_after_two
+    #   # - my_act_after_one
     #
     def run_act_callbacks(action:, format:)
       @_act_action = action.to_sym

--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -7,7 +7,6 @@ require "mime_actor/validator"
 require "active_support/callbacks"
 require "active_support/code_generator"
 require "active_support/concern"
-require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/module/attr_internal"
 
 module MimeActor
@@ -44,14 +43,14 @@ module MimeActor
         attr_reader :actions, :formats
 
         def initialize(actions, formats)
-          @actions = Array.wrap(actions).to_set(&:to_sym)
-          @formats = Array.wrap(formats).to_set(&:to_sym)
+          @actions = actions&.then { |a| Array(a).to_set(&:to_sym) }
+          @formats = formats&.then { |f| Array(f).to_set(&:to_sym) }
         end
 
         def match?(controller)
           matched = true
-          matched &= actions.include?(controller.act_action) if !actions.empty? && controller.respond_to?(:act_action)
-          matched &= formats.include?(controller.act_format) if !formats.empty? && controller.respond_to?(:act_format)
+          matched &= actions.include?(controller.act_action) if !actions.nil? && controller.respond_to?(:act_action)
+          matched &= formats.include?(controller.act_format) if !formats.nil? && controller.respond_to?(:act_format)
           matched
         end
 

--- a/lib/mime_actor/callbacks.rb
+++ b/lib/mime_actor/callbacks.rb
@@ -8,7 +8,7 @@ require "active_support/callbacks"
 require "active_support/code_generator"
 require "active_support/concern"
 require "active_support/core_ext/array/wrap"
-require "active_support/core_ext/object/blank"
+require "active_support/core_ext/module/attr_internal"
 
 module MimeActor
   # # MimeActor Callbacks
@@ -34,19 +34,25 @@ module MimeActor
     include MimeActor::Validator
 
     included do
+      attr_internal_reader :act_action, :act_format
       define_callbacks :act, skip_after_callbacks_if_terminated: true
-
       generate_act_callback_methods
     end
 
     module ClassMethods
-      class ActionMatcher
-        def initialize(actions)
-          @actions = Array.wrap(actions).to_set(&:to_s)
+      class ActMatcher
+        attr_reader :actions, :formats
+
+        def initialize(actions, formats)
+          @actions = Array.wrap(actions).to_set(&:to_sym)
+          @formats = Array.wrap(formats).to_set(&:to_sym)
         end
 
         def match?(controller)
-          @actions.include?(controller.action_name)
+          matched = true
+          matched &= actions.include?(controller.act_action) if !actions.empty? && controller.respond_to?(:act_action)
+          matched &= formats.include?(controller.act_format) if !formats.empty? && controller.respond_to?(:act_format)
+          matched
         end
 
         alias after  match?
@@ -54,41 +60,15 @@ module MimeActor
         alias around match?
       end
 
-      def callback_chain_name(format = nil)
-        if format.nil?
-          :act
-        else
-          validate!(:format, format)
-          :"act_#{format}"
-        end
-      end
-
-      def callback_chain_defined?(name)
-        !!get_callbacks(name)
-      end
-
       private
-
-      def define_callback_chain(name)
-        return if callback_chain_defined?(name)
-
-        define_callbacks name, skip_after_callbacks_if_terminated: true
-      end
 
       def configure_callbacks(callbacks, actions, formats, block)
         options = {}
-        options[:if] = ActionMatcher.new(actions) unless actions.nil?
+        options[:if] = ActMatcher.new(actions, formats) unless actions.nil? && formats.nil?
         callbacks.push(block) if block
 
-        formats = Array.wrap(formats)
-        formats << nil if formats.empty?
-
         callbacks.each do |callback|
-          formats.each do |format|
-            chain = callback_chain_name(format)
-            define_callback_chain(chain)
-            yield chain, callback, options
-          end
+          yield callback, options
         end
       end
 
@@ -116,8 +96,8 @@ module MimeActor
           batch.push(
             "def append_act_#{kind}(*callbacks, action: nil, format: nil, &block)",
             "validate_callback_options!(action, format)",
-            "configure_callbacks(callbacks, action, format, block) do |chain, callback, options|",
-            "set_callback(chain, :#{kind}, callback, options)",
+            "configure_callbacks(callbacks, action, format, block) do |callback, options|",
+            "set_callback(:act, :#{kind}, callback, options)",
             "end",
             "end"
           )
@@ -126,8 +106,8 @@ module MimeActor
           batch.push(
             "def prepend_act_#{kind}(*callbacks, action: nil, format: nil, &block)",
             "validate_callback_options!(action, format)",
-            "configure_callbacks(callbacks, action, format, block) do |chain, callback, options|",
-            "set_callback(chain, :#{kind}, callback, options.merge!(prepend: true))",
+            "configure_callbacks(callbacks, action, format, block) do |callback, options|",
+            "set_callback(:act, :#{kind}, callback, options.merge!(prepend: true))",
             "end",
             "end"
           )
@@ -136,7 +116,6 @@ module MimeActor
     end
 
     # Callbacks invocation sequence depends on the order of callback definition.
-    # (except for callbacks with `format` filter).
     #
     # @example callbacks with/without action filter
     #   act_before :my_act_before_one
@@ -192,20 +171,12 @@ module MimeActor
     #   # - my_act_after_three
     #   # - my_act_after_two
     #
-    def run_act_callbacks(format)
-      action_chain = self.class.callback_chain_name
-      format_chain = self.class.callback_chain_name(format)
+    def run_act_callbacks(action:, format:)
+      @_act_action = action.to_sym
+      @_act_format = format.to_sym
 
-      if self.class.callback_chain_defined?(format_chain)
-        run_callbacks action_chain do
-          run_callbacks format_chain do
-            yield if block_given?
-          end
-        end
-      else
-        run_callbacks action_chain do
-          yield if block_given?
-        end
+      run_callbacks :act do
+        yield if block_given?
       end
     end
   end

--- a/lib/mime_actor/stage.rb
+++ b/lib/mime_actor/stage.rb
@@ -34,13 +34,13 @@ module MimeActor
     # @param actor either a method name or a Proc to evaluate
     # @param args arguments to be passed when calling the actor
     #
-    def cue_actor(actor, *args, format:)
+    def cue_actor(actor, *args, action:, format:)
       dispatcher = MimeActor::Dispatcher.build(actor, *args)
       raise TypeError, "invalid actor, got: #{actor.inspect}" unless dispatcher
 
       self.class.validate!(:format, format)
 
-      run_act_callbacks(format) do
+      run_act_callbacks(action:, format:) do
         result = dispatcher.call(self)
         block_given? ? yield(result) : result
       end
@@ -48,7 +48,7 @@ module MimeActor
       logger.error { "actor error, cause: #{e.inspect}" } unless raise_on_actor_error
       raise e if raise_on_actor_error
     rescue StandardError => e
-      rescued = rescue_actor(e, action: action_name.to_sym, format: format)
+      rescued = rescue_actor(e, action:, format:)
       rescued || raise
     end
   end

--- a/spec/mime_actor/action_spec.rb
+++ b/spec/mime_actor/action_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe MimeActor::Action do
         expect(stub_collector).to have_received(:html) do |&block|
           allow(klazz_instance).to receive(:cue_actor).and_call_original
           expect(block.call).to eq "scene handled"
-          expect(klazz_instance).to have_received(:cue_actor).with(scene_handler, :create, :html, format: :html)
+          expect(klazz_instance).to have_received(:cue_actor).with(
+            scene_handler, :create, :html, action: :create, format: :html
+          )
         end
       end
 

--- a/spec/mime_actor/callbacks_spec.rb
+++ b/spec/mime_actor/callbacks_spec.rb
@@ -87,11 +87,9 @@ RSpec.describe MimeActor::Callbacks do
       around_callbacks
       after_callbacks
 
-      klazz.define_method(:action_name) { "placeholder" }
       klazz.define_method(:method_missing) { |*_args| "missed" }
       klazz.define_method(:respond_to_missing?) { |*_args| "responded" }
 
-      allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
       allow(klazz_instance).to receive(:method_missing).and_wrap_original do |_method, method_name, *_args, &block|
         sequence << method_name
         block&.call
@@ -99,7 +97,6 @@ RSpec.describe MimeActor::Callbacks do
     end
 
     context "with or without action filter" do
-      let(:act_action) { :create }
       let(:before_callbacks) do
         klazz.act_before :my_act_before_one
         klazz.act_before :my_act_before_two, action: :create
@@ -117,7 +114,7 @@ RSpec.describe MimeActor::Callbacks do
       end
 
       it "calls in order" do
-        klazz_instance.run_act_callbacks(:html)
+        klazz_instance.run_act_callbacks(action: :create, format: :html)
         expect(sequence).to eq %i[
           my_act_before_one
           my_act_before_two
@@ -133,7 +130,6 @@ RSpec.describe MimeActor::Callbacks do
     end
 
     context "with format filter" do
-      let(:act_action) { :create }
       let(:before_callbacks) do
         klazz.act_before :my_act_before_one
         klazz.act_before :my_act_before_two, action: :create
@@ -154,20 +150,20 @@ RSpec.describe MimeActor::Callbacks do
       end
 
       it "calls in order" do
-        klazz_instance.run_act_callbacks(:html)
+        klazz_instance.run_act_callbacks(action: :create, format: :html)
         expect(sequence).to eq %i[
           my_act_before_one
           my_act_before_two
+          my_act_before_three
           my_act_before_four
           my_act_around_one
+          my_act_around_two
           my_act_around_three
           my_act_around_four
-          my_act_before_three
-          my_act_around_two
-          my_act_after_one
           my_act_after_four
           my_act_after_three
           my_act_after_two
+          my_act_after_one
         ]
       end
     end
@@ -191,10 +187,8 @@ RSpec.describe MimeActor::Callbacks do
       end
 
       context "with action name :create" do
-        let(:act_action) { :create }
-
         it "calls xml callbacks in order" do
-          klazz_instance.run_act_callbacks(:xml)
+          klazz_instance.run_act_callbacks(action: :create, format: :xml)
           expect(sequence).to eq %i[
             before_a
             before_anything
@@ -205,26 +199,26 @@ RSpec.describe MimeActor::Callbacks do
         end
 
         it "calls html callbacks in order" do
-          klazz_instance.run_act_callbacks(:html)
+          klazz_instance.run_act_callbacks(action: :create, format: :html)
           expect(sequence).to eq %i[
             before_a
+            before_f
             before_anything
             around_anything
-            before_f
-            after_f
             after_anything
+            after_f
             after_a
           ]
         end
 
         it "calls json callbacks in order" do
-          klazz_instance.run_act_callbacks(:json)
+          klazz_instance.run_act_callbacks(action: :create, format: :json)
           expect(sequence).to eq %i[
             before_a
-            before_anything
-            around_anything
             before_f
+            before_anything
             around_f
+            around_anything
             after_anything
             after_a
           ]
@@ -232,10 +226,8 @@ RSpec.describe MimeActor::Callbacks do
       end
 
       context "with action name :show" do
-        let(:act_action) { :show }
-
         it "calls xml callbacks in order" do
-          klazz_instance.run_act_callbacks(:xml)
+          klazz_instance.run_act_callbacks(action: :show, format: :xml)
           expect(sequence).to eq %i[
             before_a
             before_anything
@@ -246,29 +238,29 @@ RSpec.describe MimeActor::Callbacks do
         end
 
         it "calls html callbacks in order" do
-          klazz_instance.run_act_callbacks(:html)
+          klazz_instance.run_act_callbacks(action: :show, format: :html)
           expect(sequence).to eq %i[
             before_a
+            before_f
             before_anything
             around_a
             around_anything
-            before_f
-            after_f
             after_anything
+            after_f
           ]
         end
 
         it "calls json callbacks in order" do
-          klazz_instance.run_act_callbacks(:json)
+          klazz_instance.run_act_callbacks(action: :show, format: :json)
           expect(sequence).to eq %i[
             before_a
+            before_f
             before_anything
             around_a
-            around_anything
-            before_f
             around_f
-            after_a_f
+            around_anything
             after_anything
+            after_a_f
           ]
         end
       end

--- a/spec/mime_actor/stage_spec.rb
+++ b/spec/mime_actor/stage_spec.rb
@@ -68,7 +68,13 @@ RSpec.describe MimeActor::Stage do
 
       context "with block passed" do
         let(:cue) do
-          klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter, &another_actor)
+          klazz_instance.cue_actor(
+            actor,
+            *acting_instructions,
+            action: action_filter,
+            format: format_filter,
+            &another_actor
+          )
         end
         let(:actor) { -> { 4 } }
         let(:another_actor) { ->(num) { num**num } }

--- a/spec/support/shared_context/shared_context_for_callbacks.rb
+++ b/spec/support/shared_context/shared_context_for_callbacks.rb
@@ -5,10 +5,5 @@ RSpec.shared_context "with act callbacks" do
   let(:klazz_instance) { klazz.new }
   let(:act_format) { :html }
   let(:act_action) { :create }
-  let(:run) { klazz_instance.run_act_callbacks(act_format) }
-
-  before do
-    klazz.define_method(:action_name) { "placholder" }
-    allow(klazz_instance).to receive(:action_name).and_return(act_action.to_s)
-  end
+  let(:run) { klazz_instance.run_act_callbacks(action: act_action, format: act_format) }
 end

--- a/spec/support/shared_context/shared_context_for_stage.rb
+++ b/spec/support/shared_context/shared_context_for_stage.rb
@@ -10,12 +10,10 @@ RSpec.shared_context "with stage cue" do
   let(:format_filter) { :html }
   let(:stub_logger) { instance_double(ActiveSupport::Logger) }
   let(:cue) do
-    klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter)
+    klazz_instance.cue_actor(actor, *acting_instructions, action: action_filter, format: format_filter)
   end
 
   before do
-    klazz.define_method(:action_name) { "placeholder" }
-    allow(klazz_instance).to receive(:action_name).and_return(action_filter.to_s)
     klazz.config.logger = stub_logger
   end
 end

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -48,7 +48,13 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
 
     context "with block passed" do
       let(:cue) do
-        klazz_instance.cue_actor(actor, *acting_instructions, format: format_filter, &another_block)
+        klazz_instance.cue_actor(
+          actor,
+          *acting_instructions,
+          action: action_filter,
+          format: format_filter,
+          &another_block
+        )
       end
       let(:another_block) { ->(num) { num**num } }
 


### PR DESCRIPTION
Previously, callbacks were stored in different chains due to the nature of `ActiveSupport::Callbacks` evaluate `if` and `unless` conditions base on the state on the class.

For example, `before_action :test, only: :create` requires the class to have a method `action_name` to indicate the current action (the `action_name` is provided out of the box in `AbstractController#process_action` by setting an internal attribute `action_name`)

With this PR, the gem will store the current `action` and `format` it is cueing under internal attributes `act_action` and `act_format`. These attributes will be set when `#run_act_callbacks(action: :create, format: :html)` is called.

This behavior will be provided out of the box when using `MimeActor::Action` that exposes `#start_scene` that process current action with each format configured.