### PR TITLE
feat: tagged logging

### DIFF
--- a/lib/mime_actor/action.rb
+++ b/lib/mime_actor/action.rb
@@ -67,8 +67,9 @@ module MimeActor
             next
           end
 
-          dispatch = -> { cue_actor(callable, action, format, action:, format:) }
-          collector.public_send(format, &dispatch)
+          collector.public_send(format) do
+            fill_run_sheet(action, format) { cue_actor(callable, action, format, action:, format:) }
+          end
         end
       end
     end

--- a/spec/mime_actor/railtie_spec.rb
+++ b/spec/mime_actor/railtie_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MimeActor::Railtie do
 
   before do
     app.config.eager_load = false
-    app.config.logger = ActiveSupport::Logger.new($stdout)
+    app.config.logger = ActiveSupport::Logger.new(nil)
     app.config.load_defaults Rails.gem_version.segments.take(2).join(".")
     app.initialize!
   end

--- a/spec/support/shared_context/shared_context_for_stage.rb
+++ b/spec/support/shared_context/shared_context_for_stage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/logger"
+require "active_support/tagged_logging"
 
 RSpec.shared_context "with stage cue" do
   let(:klazz) { Class.new.include described_class }
@@ -8,7 +9,8 @@ RSpec.shared_context "with stage cue" do
   let(:acting_instructions) { [] }
   let(:action_filter) { :create }
   let(:format_filter) { :html }
-  let(:stub_logger) { instance_double(ActiveSupport::Logger) }
+  let(:log_output) { nil }
+  let(:stub_logger) { ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(log_output)) }
   let(:cue) do
     klazz_instance.cue_actor(actor, *acting_instructions, action: action_filter, format: format_filter)
   end

--- a/spec/support/shared_examples/shared_examples_for_stage.rb
+++ b/spec/support/shared_examples/shared_examples_for_stage.rb
@@ -69,7 +69,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
   end
 
   context "when actor method does not exist" do
-    before { allow(stub_logger).to receive(:error).and_yield }
+    let(:log_output) { StringIO.new }
 
     it "returns nil" do
       expect(cue).to be_nil
@@ -77,9 +77,7 @@ RSpec.shared_examples "stage cue actor method" do |actor_method|
 
     it "logs a error message" do
       expect(cue).to be_nil
-      expect(stub_logger).to have_received(:error) do |&logger|
-        expect(logger.call).to eq "actor error, cause: <MimeActor::ActorNotFound> #{actor.inspect} not found"
-      end
+      expect(log_output.string).to eq "actor error, cause: <MimeActor::ActorNotFound> #{actor.inspect} not found\n"
     end
 
     context "when raise_on_actor_error is set" do


### PR DESCRIPTION
Resolve #64 

add tagged logging wrapper around #cue_actor which will be appleid for `callbacks`, `rescue handlers` and `action methods`