### PR TITLE
spec: rails edge rack input env

### DIFF
--- a/spec/action_controller/metal_spec.rb
+++ b/spec/action_controller/metal_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe ActionController::Metal do
   let(:env) do
     {
       "REQUEST_METHOD" => "POST",
-      "HTTP_ACCEPT"    => "application/json,application/xml",
-      "rack.input"     => "" # required for ActionPack <= 7.0
+      "HTTP_ACCEPT"    => "application/json,application/xml"
     }
   end
   let(:act_action) { :new }
@@ -28,6 +27,7 @@ RSpec.describe ActionController::Metal do
 
   before do
     controller_class.config.logger = stub_logger
+    env["rack.input"] = "" if ActionPack.version < "7.1"
   end
 
   describe "when actor method is defined" do

--- a/spec/examples/events_controller_spec.rb
+++ b/spec/examples/events_controller_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe EventsController do
     {
       "REQUEST_METHOD" => request_method,
       "HTTP_ACCEPT"    => request_accept,
-      "QUERY_STRING"   => request_params,
-      "rack.input"     => "" # required for ActionPack <= 7.0
+      "QUERY_STRING"   => request_params
     }
   end
   let(:action_request) { ActionDispatch::Request.new(env) }
@@ -20,6 +19,7 @@ RSpec.describe EventsController do
 
   before do
     described_class.config.logger = stub_logger
+    env["rack.input"] = "" if ActionPack.version < "7.1"
   end
 
   {


### PR DESCRIPTION
`rack.input` is optional now