### PR TITLE
lib: bump rexml >= 3.3.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 7.2", ">= 7.2.1.1"
 group :development, :test do
   gem "rails", "~> 7.2", ">= 7.2.1.1"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,8 +189,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -235,7 +234,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     stringio (3.1.1)
-    strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -263,6 +261,7 @@ DEPENDENCIES
   mime_actor!
   rails (~> 7.2, >= 7.2.1.1)
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 6.1.0"
 group :development, :test do
   gem "rails", "~> 6.1.0"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -234,6 +234,7 @@ DEPENDENCIES
   mime_actor!
   rails (~> 6.1.0)
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 7.0.0"
 group :development, :test do
   gem "rails", "~> 7.0.0"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   mime_actor!
   rails (~> 7.0.0)
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 7.1.0"
 group :development, :test do
   gem "rails", "~> 7.1.0"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -263,6 +263,7 @@ DEPENDENCIES
   mime_actor!
   rails (~> 7.1.0)
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 7.2.0"
 group :development, :test do
   gem "rails", "~> 7.2.0"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -261,6 +261,7 @@ DEPENDENCIES
   mime_actor!
   rails (~> 7.2.0)
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -10,6 +10,7 @@ gem "activesupport", github: "rails/rails", branch: "main"
 group :development, :test do
   gem "rails", github: "rails/rails", branch: "main"
   gem "rake", ">= 11.0"
+  gem "rexml", ">= 3.3.9"
   gem "rspec", "~> 3.12"
   gem "rspec-activesupport", "~> 0.1"
   gem "simplecov", "~> 0.22.0", require: false

--- a/gemfiles/rails_edge.gemfile.lock
+++ b/gemfiles/rails_edge.gemfile.lock
@@ -270,6 +270,7 @@ DEPENDENCIES
   mime_actor!
   rails!
   rake (>= 11.0)
+  rexml (>= 3.3.9)
   rspec (~> 3.12)
   rspec-activesupport (~> 0.1)
   rubocop (>= 1.28.2)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/10/28/redos-rexml-cve-2024-49761/